### PR TITLE
cd/travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,7 @@ matrix:
           env: TOXENV=py36
         - python: 3.7
           env: TOXENV=py37
+          dist: xenial
+          sudo: true
         - python: pypy
           env: TOXENV=pypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: python
+install:
+      - pip install tox
+script:
+      - tox
+matrix:
+    include:
+        - python: 2.7
+          env: TOXENV=py27
+        - python: 3.5
+          env: TOXENV=py35
+        - python: 3.6
+          env: TOXENV=py36
+        - python: 3.7
+          env: TOXENV=py37
+        - python: pypy
+          env: TOXENV=pypy


### PR DESCRIPTION
Add support for limited testing with travis-ci

This uses the matrix style for engaging with tox and tests
py27, 35, 36, 37 and pypy.