### PR TITLE
py3 fixes for form handling in paste.fixture

### DIFF
--- a/paste/debug/debugapp.py
+++ b/paste/debug/debugapp.py
@@ -54,14 +54,14 @@ class SlowConsumer(object):
                     time.sleep(self.delay)
             body = "<html><body>%d bytes</body></html>" % size
         else:
-            body = ('<html><body>\n'
-                '<form method="post" enctype="multipart/form-data">\n'
-                '<input type="file" name="file">\n'
-                '<input type="submit" >\n'
-                '</form></body></html>\n')
+            body = (b'<html><body>\n'
+                    b'<form method="post" enctype="multipart/form-data">\n'
+                    b'<input type="file" name="file">\n'
+                    b'<input type="submit" >\n'
+                    b'</form></body></html>\n')
         print("bingles")
         start_response("200 OK", [('Content-Type', 'text/html'),
-                                  ('Content-Length', len(body))])
+                                  ('Content-Length', str(len(body)))])
         return [body]
 
 def make_test_app(global_conf):

--- a/paste/fixture.py
+++ b/paste/fixture.py
@@ -557,7 +557,10 @@ class TestResponse(object):
         forms = self._forms_indexed = {}
         form_texts = []
         started = None
-        for match in self._tag_re.finditer(self.body):
+        body = self.body
+        if not six.PY2:
+            body = body.decode('utf8', 'xmlcharrefreplace')
+        for match in self._tag_re.finditer(body):
             end = match.group(1) == '/'
             tag = match.group(2).lower()
             if tag != 'form':
@@ -961,8 +964,11 @@ class Form(object):
         in_select = None
         in_textarea = None
         fields = {}
-        for match in self._tag_re.finditer(self.text):
-            end = match.group(1) == '/'
+        text = self.text
+        if not six.PY2:
+            text = text.decode('utf8', 'xmlcharrefreplace')
+        for match in self._tag_re.finditer(text):
+            end = match.group(1) == b'/'
             tag = match.group(2).lower()
             if tag not in ('input', 'select', 'option', 'textarea',
                            'button'):
@@ -1020,7 +1026,10 @@ class Form(object):
 
     def _parse_action(self):
         self.action = None
-        for match in self._tag_re.finditer(self.text):
+        text = self.text
+        if not six.PY2:
+            text = text.decode('utf8', 'xmlcharrefreplace')
+        for match in self._tag_re.finditer(text):
             end = match.group(1) == '/'
             tag = match.group(2).lower()
             if tag != 'form':

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -1,5 +1,6 @@
-from paste.debug.debugapp import SimpleApplication
+from paste.debug.debugapp import SimpleApplication, SlowConsumer
 from paste.fixture import TestApp
+
 
 def test_fixture():
     app = TestApp(SimpleApplication())
@@ -26,3 +27,11 @@ def test_fixture():
     assert ('one=first' in hc)
     assert ('two=second' in hc)
     assert ('three=' in hc)
+
+
+def test_fixture_form():
+    app = TestApp(SlowConsumer())
+    res = app.get('/')
+    form = res.forms[0]
+    assert 'file' in form.fields
+    assert form.action == ''


### PR DESCRIPTION
It uses "not six.PY2" in contrast to other places in the code to be
forward-compatible.

I've not looked too closely, but it might make sense to decode body/text
in the beginning already, instead of having it as bytes internally?!

Also, like mentioned in [1] already, it should probably use the correct
source encoding?!

1: https://github.com/cdent/paste/blob/36e5b8bd16a6063ec654faf04541f3a20d19f7fe/paste/fixture.py#L820