### PR TITLE
paste.fixture: fix form offset handling

### DIFF
--- a/paste/fixture.py
+++ b/paste/fixture.py
@@ -568,14 +568,14 @@ class TestResponse(object):
             if end:
                 assert started, (
                     "</form> unexpected at %s" % match.start())
-                form_texts.append(self.body[started:match.end()])
+                form_texts.append(body[started:match.end()])
                 started = None
             else:
                 assert not started, (
                     "Nested form tags at %s" % match.start())
                 started = match.start()
         assert not started, (
-            "Danging form: %r" % self.body[started:])
+            "Dangling form: %r" % body[started:])
         for i, text in enumerate(form_texts):
             form = Form(self, text)
             forms[i] = form
@@ -965,8 +965,6 @@ class Form(object):
         in_textarea = None
         fields = {}
         text = self.text
-        if not six.PY2:
-            text = text.decode('utf8', 'xmlcharrefreplace')
         for match in self._tag_re.finditer(text):
             end = match.group(1) == b'/'
             tag = match.group(2).lower()
@@ -1027,8 +1025,6 @@ class Form(object):
     def _parse_action(self):
         self.action = None
         text = self.text
-        if not six.PY2:
-            text = text.decode('utf8', 'xmlcharrefreplace')
         for match in self._tag_re.finditer(text):
             end = match.group(1) == '/'
             tag = match.group(2).lower()

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -35,3 +35,12 @@ def test_fixture_form():
     form = res.forms[0]
     assert 'file' in form.fields
     assert form.action == ''
+
+
+def test_fixture_form_end():
+    def response(environ, start_response):
+        body = b"<html><body><form>sm\xc3\xb6rebr\xc3\xb6</form></body></html>"
+        start_response("200 OK", [('Content-Type', 'text/html'),
+                                  ('Content-Length', str(len(body)))])
+        return [body]
+    TestApp(response).get('/')


### PR DESCRIPTION
It would fail if the length of bytes and unicode differs.

It now passes non-bytes to `Form` directly.