### PR TITLE
lint: ErrorWrapper.write: remove assertion

### DIFF
--- a/paste/lint.py
+++ b/paste/lint.py
@@ -217,7 +217,6 @@ class ErrorWrapper(object):
         self.errors = wsgi_errors
 
     def write(self, s):
-        assert isinstance(s, bytes)
         self.errors.write(s)
 
     def flush(self):


### PR DESCRIPTION
With webpy non-bytes might arrive here, via:

    print(traceback.format_exc(), file=web.debug)
    out = ctx.environ['wsgi.errors']
    out.write(x)

I think this is legitimate, and paste should not cause more trouble
(i.e. a new exception) in this case.