### PR TITLE
Remove use of _lock around get and set timeout of SSL connection

### DIFF
--- a/paste/httpserver.py
+++ b/paste/httpserver.py
@@ -361,7 +361,7 @@ else:
         Provides SSL server functionality on top of the BaseHTTPServer
         by overriding _private_ members of Python's standard
         distribution. The interface for this instance only changes by
-        adding a an optional ssl_context attribute to the constructor:
+        adding an optional ssl_context attribute to the constructor:
 
               cntx = SSL.Context(SSL.SSLv23_METHOD)
               cntx.use_privatekey_file("host.pem")
@@ -379,20 +379,7 @@ else:
                                         self.socket_type)
             self.ssl_context = ssl_context
             if ssl_context:
-                class SSLConnection(SSL.Connection):
-                    def settimeout(self, *args):
-                        self._lock.acquire()
-                        try:
-                            return self._ssl_conn.settimeout(*args)
-                        finally:
-                            self._lock.release()
-                    def gettimeout(self):
-                        self._lock.acquire()
-                        try:
-                            return self._ssl_conn.gettimeout()
-                        finally:
-                            self._lock.release()
-                self.socket = SSLConnection(ssl_context, self.socket)
+                self.socket = SSL.Connection(ssl_context, self.socket)
             self.server_bind()
             if request_queue_size:
                 self.socket.listen(request_queue_size)


### PR DESCRIPTION
The maintainers of pyOpenSSL have deprecated the tsafe module
because it is neither used nor complete. It was removed from
in paste in 78dd2ec01384 but because of a lack of test coverage
it caused a regression as described in #19.

Reviewing the code and pyOpenSSL, it appears that the right
fix is to simply not subclass the SSL.Connection, and let
get and set timeout be called on the socket object that
Connection keeps, without a lock.

A concern here is that if someone is doing something multi-
threaded with paste/httpserver the removal of the use of tsafe
may present some issues. On the other hand, if someone is
doing something multi-threaded, one hopes they are using a
more robust web and modern web server.

Fixes #19