### PR TITLE
Write bytestrings when calling wsgi_write_chunk

### DIFF
--- a/paste/httpserver.py
+++ b/paste/httpserver.py
@@ -306,7 +306,7 @@ class WSGIHandlerMixin:
                 for chunk in result:
                     self.wsgi_write_chunk(chunk)
                 if not self.wsgi_headers_sent:
-                    self.wsgi_write_chunk('')
+                    self.wsgi_write_chunk(b'')
             finally:
                 if hasattr(result,'close'):
                     result.close()
@@ -321,7 +321,7 @@ class WSGIHandlerMixin:
                     '500 Internal Server Error',
                     [('Content-type', 'text/plain'),
                      ('Content-length', str(len(error_msg)))])
-                self.wsgi_write_chunk("Internal Server Error\n")
+                self.wsgi_write_chunk(b"Internal Server Error\n")
             raise
 
 #


### PR DESCRIPTION
httpservers writes an empty string or an internal server
error message, these needs to be bytes in python 3.

It might have been useful to have wsgi_write_chunk accept
either bytes or strings and do the right thing, but that
seemed too invasive to be safe.