### PR TITLE
Get MutableMapping from collections.abc on Python 3.

### DIFF
--- a/paste/request.py
+++ b/paste/request.py
@@ -30,7 +30,7 @@ except ImportError:
 try:
     from UserDict import DictMixin
 except ImportError:
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
 import six
 
 from paste.util.multidict import MultiDict

--- a/paste/urlmap.py
+++ b/paste/urlmap.py
@@ -9,7 +9,7 @@ import os
 from paste.util import html
 try:
     # Python 3
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
 except ImportError:
     # Python 2
     from UserDict import DictMixin

--- a/paste/util/multidict.py
+++ b/paste/util/multidict.py
@@ -7,7 +7,7 @@ import sys
 
 try:
     # Python 3
-    from collections import MutableMapping as DictMixin
+    from collections.abc import MutableMapping as DictMixin
 except ImportError:
     # Python 2
     from UserDict import DictMixin


### PR DESCRIPTION
This fixes a deprecation warning on 3.7.