### PR TITLE
Avoid copying FieldStorage if possible.

### DIFF
--- a/paste/util/multidict.py
+++ b/paste/util/multidict.py
@@ -265,11 +265,13 @@ class UnicodeMultiDict(DictMixin):
         """
         if isinstance(value, cgi.FieldStorage):
             # decode FieldStorage's field name and filename
-            value = copy.copy(value)
-            if self.decode_keys and isinstance(value.name, six.binary_type):
-                value.name = value.name.decode(self.encoding, self.errors)
-            if six.PY2:
-                value.filename = value.filename.decode(self.encoding, self.errors)
+            decode_name = self.decode_keys and isinstance(value.name, six.binary_type)
+            if six.PY2 or decode_name:
+                value = copy.copy(value)
+                if decode_name:
+                    value.name = value.name.decode(self.encoding, self.errors)
+                if six.PY2:
+                    value.filename = value.filename.decode(self.encoding, self.errors)
         else:
             try:
                 value = value.decode(self.encoding, self.errors)


### PR DESCRIPTION
On Python 3, cgi.FieldStorage has a __del__ method that closes the underlying file [1]. This means that if the copy made from UnicodeMultiDict._decode_value is garbage collected, the file underlying the original FieldStorage will be closed! Fix this by not copying FieldStorage if it is not required by decode_keys=False. I cannot think of a nice way to fix this problem if decode_keys=True.

[1] https://github.com/python/cpython/commit/f79126f373a9d5c9b584a8db736fe490fcbfa77a