### PR TITLE
TestApp: Make unicode urls always work.

### DIFF
--- a/paste/fixture.py
+++ b/paste/fixture.py
@@ -235,6 +235,7 @@ class TestApp(object):
             environ['CONTENT_TYPE'] = content_type
         elif params:
             environ.setdefault('CONTENT_TYPE', 'application/x-www-form-urlencoded')
+        url = str(url)
         if '?' in url:
             url, environ['QUERY_STRING'] = url.split('?', 1)
         else:

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -72,3 +72,10 @@ def test_params_and_upload_files():
     assert params['file1'].filename == 'myfile.txt'
     assert params['file2'].value == b'data2'
     assert params['file2'].filename == 'yourfile.txt'
+
+def test_unicode_path():
+    app = TestApp(SimpleApplication())
+    app.get(u"/?")
+    app.post(u"/?")
+    app.put(u"/?")
+    app.delete(u"/?")


### PR DESCRIPTION
Passing a unicode url to get() always worked (assuming the url contained only ASCII), but it didn't work to post(), put(), or delete() if query parameters were included. This change fixes the latter cases.