### PR TITLE
Fix deprecation warnings

### DIFF
--- a/paste/auth/cookie.py
+++ b/paste/auth/cookie.py
@@ -144,10 +144,17 @@ class AuthCookieSigner(object):
         if six.PY3:
             content = content.encode('utf8')
             timestamp = timestamp.encode('utf8')
-        cookie = base64.encodebytes(
-            hmac.new(self.secret, content, sha1).digest() +
-            timestamp +
-            content)
+
+        if six.PY3:
+            cookie = base64.encodebytes(
+                hmac.new(self.secret, content, sha1).digest() +
+                timestamp +
+                content)
+        else:
+            cookie = base64.encodestring(
+                hmac.new(self.secret, content, sha1).digest() +
+                timestamp +
+                content)
         cookie = cookie.replace(b"/", b"_").replace(b"=", b"~")
         cookie = cookie.replace(b'\n', b'').replace(b'\r', b'')
         if len(cookie) > self.maxlen:

--- a/paste/auth/cookie.py
+++ b/paste/auth/cookie.py
@@ -144,7 +144,7 @@ class AuthCookieSigner(object):
         if six.PY3:
             content = content.encode('utf8')
             timestamp = timestamp.encode('utf8')
-        cookie = base64.encodestring(
+        cookie = base64.encodebytes(
             hmac.new(self.secret, content, sha1).digest() +
             timestamp +
             content)

--- a/paste/httpserver.py
+++ b/paste/httpserver.py
@@ -952,7 +952,7 @@ class ThreadPool(object):
         hung_workers = []
         for worker in self.workers:
             worker.join(0.5)
-            if worker.isAlive():
+            if worker.is_alive():
                 hung_workers.append(worker)
         zombies = []
         for thread_id in self.dying_threads:
@@ -969,10 +969,10 @@ class ThreadPool(object):
                 timed_out = False
                 need_force_quit = bool(zombies)
                 for worker in self.workers:
-                    if not timed_out and worker.isAlive():
+                    if not timed_out and worker.is_alive():
                         timed_out = True
                         worker.join(force_quit_timeout)
-                    if worker.isAlive():
+                    if worker.is_alive():
                         print("Worker %s won't die" % worker)
                         need_force_quit = True
                 if need_force_quit:


### PR DESCRIPTION
* Use `is_alive` instead of `isAlive` for  Python 3.9 compatibility. Ref : https://github.com/python/cpython/pull/15225
* Use `encodebytes` to fix deprecation warning.

Fixes #40 
Fixes #39 