### PR TITLE
Make gzip middleware stop producing a spurious response body on HEAD requests

### DIFF
--- a/paste/fixture.py
+++ b/paste/fixture.py
@@ -299,6 +299,18 @@ class TestApp(object):
                                  extra_environ=extra_environ,status=status,
                                  upload_files=None, expect_errors=expect_errors)
 
+    def head(self, url, headers=None, extra_environ=None,
+             status=None, expect_errors=False):
+        """
+        Do a HEAD request.  Very like the ``.get()`` method.
+
+        Returns a `response object
+        <class-paste.fixture.TestResponse.html>`_
+        """
+        return self._gen_request('HEAD', url, headers=headers,
+                                 extra_environ=extra_environ,status=status,
+                                 upload_files=None, expect_errors=expect_errors)
+
 
 
 

--- a/paste/gzipper.py
+++ b/paste/gzipper.py
@@ -25,9 +25,12 @@ class middleware(object):
         self.compress_level = int(compress_level)
 
     def __call__(self, environ, start_response):
-        if 'gzip' not in environ.get('HTTP_ACCEPT_ENCODING', ''):
+        if 'gzip' not in environ.get('HTTP_ACCEPT_ENCODING', '') \
+           or environ['REQUEST_METHOD'] == 'HEAD':
             # nothing for us to do, so this middleware will
-            # be a no-op:
+            # be a no-op (there's no body expected in the HEAD case,
+            # and if we open a GzipFile we would produce an erroneous
+            # 20-byte header and trailer):
             return self.application(environ, start_response)
         response = GzipResponse(start_response, self.compress_level)
         app_iter = self.application(environ,

--- a/tests/test_gzipper.py
+++ b/tests/test_gzipper.py
@@ -4,8 +4,10 @@ import gzip
 import six
 
 def simple_app(environ, start_response):
-    start_response('200 OK', [('content-type', 'text/plain')])
-    return [b'this is a test']
+    start_response('200 OK',
+                   [('content-type', 'text/plain'),
+                    ('content-length', '0')])
+    return [b'this is a test'] if environ['REQUEST_METHOD'] != 'HEAD' else []
 
 wsgi_app = middleware(simple_app)
 app = TestApp(wsgi_app)
@@ -17,3 +19,9 @@ def test_gzip():
     assert res.body != b'this is a test'
     actual = gzip.GzipFile(fileobj=six.BytesIO(res.body)).read()
     assert actual == b'this is a test'
+
+def test_gzip_head():
+    res = app.head(
+        '/', extra_environ=dict(HTTP_ACCEPT_ENCODING='gzip'))
+    assert int(res.header('content-length')) == 0
+    assert res.body == b''


### PR DESCRIPTION
Fixes #43

(It seems news.txt is maintained separately so I didn't make a change there. Let me know if I should.)