### PR TITLE
StringIO imports differently in python 3 - use six for compatibility

### DIFF
--- a/paste/cascade.py
+++ b/paste/cascade.py
@@ -8,7 +8,7 @@ return ``404 Not Found``.
 from paste import httpexceptions
 from paste.util import converters
 import tempfile
-from cStringIO import StringIO
+from six.moves import cStringIO as StringIO
 
 __all__ = ['Cascade']
 


### PR DESCRIPTION
cStringIO does not exist in python3, we would like to use this module in python 3.  Thanks!