### PR TITLE
Make next handling in wsgilib more py3-compatible

### DIFF
--- a/paste/wsgilib.py
+++ b/paste/wsgilib.py
@@ -119,10 +119,10 @@ class chained_app_iters(object):
 
     def next(self):
         if len(self.chained) == 1:
-            return self.chained[0].next()
+            return six.next(self.chained[0])
         else:
             try:
-                return self.chained[0].next()
+                return six.next(self.chained[0])
             except StopIteration:
                 self.chained.pop(0)
                 return self.next()
@@ -261,7 +261,7 @@ class _wrap_app_iter_app(object):
 
     def next(self):
         try:
-            return self.app_iter.next()
+            return six.next(self.app_iter)
         except StopIteration:
             if self.ok_callback:
                 self.ok_callback()
@@ -278,7 +278,7 @@ class _wrap_app_iter_app(object):
             app_iter = iter(new_app_iterable)
             if hasattr(new_app_iterable, 'close'):
                 self.close = new_app_iterable.close
-            self.next = app_iter.next
+            self.next = lambda: six.next(app_iter)
             return self.next()
     __next__ = next
 


### PR DESCRIPTION
If the app-iterator being passed in is not defining `next()` (e.g. running under py3 and only defined `__next__`), this will currently crash.

Fix by using `six.next` which will use `__next__` or `next` as appropriate.