### PR TITLE
Py3-compat middleware.py's make_table's item sort

### DIFF
--- a/paste/evalexception/middleware.py
+++ b/paste/evalexception/middleware.py
@@ -456,8 +456,7 @@ class EvalHTMLFormatter(formatter.HTMLFormatter):
 
 def make_table(items):
     if isinstance(items, dict):
-        items = items.items()
-        items.sort()
+        items = sorted(items.items())
     rows = []
     i = 0
     for name, value in items:


### PR DESCRIPTION
In py2 an array is created and sorted, and in py3 an array of the items needs to be realized in the same fashion hence the sorted(•) fix. Otherwise the code will fail on Python 3 since dict.items() returns a view on the items which doesn't have a .sort() method.