### PR TITLE
Fix ImportError with setuptools 50.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ __version__ = '3.4.3'
 
 from setuptools import setup, find_packages
 import sys, os
-sys.path.insert(0, os.path.join(os.path.dirname(__file__),
+sys.path.append(os.path.join(os.path.dirname(__file__),
                                 'paste', 'util'))
 import finddata
 


### PR DESCRIPTION
New version of setuptools uses `html` module from standart library
which collides with `paste.util.html`. Instead of inserting it into
first position of sys.path, this commit appends it to the end.

Building tested in COPR: https://copr.fedorainfracloud.org/coprs/thrnciar/python-setuptools/build/1654052/

Fixes: #57