### PR TITLE
Add an explicit dependency on setuptools for pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,10 @@ setup(name="Paste",
           exclude_directories=finddata.standard_exclude_directories + ('tests',)),
       namespace_packages=['paste'],
       zip_safe=False,
-      install_requires=['six>=1.4.0'],
+      install_requires=[
+        'setuptools',  # pkg_resources
+        'six>=1.4.0',
+        ],
       extras_require={
         'subprocess': [],
         'hotshot': [],


### PR DESCRIPTION
Since Paste uses pkg_resources explicitly, it should have a runtime
dependency on setuptools.  While this does not make any difference
to pip users right now, it helps packagers correctly determine
the dependencies, for packaging systems that can remove/skip build-time
dependencies.