### PR TITLE
Wsgi.errors is text

### DIFF
--- a/paste/cgiapp.py
+++ b/paste/cgiapp.py
@@ -253,7 +253,7 @@ def proc_communicate(proc, stdin=None, stdout=None, stderr=None):
                 read_set.remove(proc.stderr)
             if trans_nl:
                 data = proc._translate_newlines(data)
-            stderr.write(data)
+            stderr.write(six.ensure_text(data))
 
     try:
         proc.wait()

--- a/paste/errordocument.py
+++ b/paste/errordocument.py
@@ -87,8 +87,6 @@ class StatusKeeper(object):
             return self.app(environ, keep_status_start_response)
         except RecursionLoop as e:
             line = 'Recursion error getting error page: %s\n' % e
-            if six.PY3:
-                line = line.encode('utf8')
             environ['wsgi.errors'].write(line)
             keep_status_start_response('500 Server Error', [('Content-type', 'text/plain')], sys.exc_info())
             body = ('Error: %s.  (Error page could not be fetched)'

--- a/paste/evalexception/middleware.py
+++ b/paste/evalexception/middleware.py
@@ -333,8 +333,6 @@ class EvalException(object):
                                headers,
                                exc_info)
             msg = 'Debug at: %s\n' % view_uri
-            if six.PY3:
-                msg = msg.encode('utf8')
             environ['wsgi.errors'].write(msg)
 
             exc_data = collector.collect_exception(*exc_info)

--- a/paste/exceptions/errormiddleware.py
+++ b/paste/exceptions/errormiddleware.py
@@ -221,7 +221,7 @@ class CatchingIter(object):
         if self.closed:
             raise StopIteration
         try:
-            return self.app_iterator.next()
+            return next(self.app_iterator)
         except StopIteration:
             self.closed = True
             close_response = self._close()

--- a/paste/exceptions/errormiddleware.py
+++ b/paste/exceptions/errormiddleware.py
@@ -386,8 +386,6 @@ def handle_exception(exc_info, error_stream, html=True,
     else:
         line = ('Error - %s: %s\n'
                 % (exc_data.exception_type, exc_data.exception_value))
-        if six.PY3:
-            line = line.encode('utf8')
         error_stream.write(line)
     if html:
         if debug_mode and simple_html_error:

--- a/paste/lint.py
+++ b/paste/lint.py
@@ -217,7 +217,7 @@ class ErrorWrapper(object):
         self.errors = wsgi_errors
 
     def write(self, s):
-        assert isinstance(s, bytes)
+        assert isinstance(s, six.string_types)
         self.errors.write(s)
 
     def flush(self):

--- a/paste/wsgilib.py
+++ b/paste/wsgilib.py
@@ -291,7 +291,7 @@ def raw_interactive(application, path='', raise_on_wsgi_error=False,
     if raise_on_wsgi_error:
         errors = ErrorRaiser()
     else:
-        errors = six.BytesIO()
+        errors = six.StringIO()
     basic_environ = {
         # mandatory CGI variables
         'REQUEST_METHOD': 'GET',     # always mandatory
@@ -604,4 +604,3 @@ for _name in __all__:
 if __name__ == '__main__':
     import doctest
     doctest.testmod()
-

--- a/tests/test_cgiapp.py
+++ b/tests/test_cgiapp.py
@@ -57,5 +57,4 @@ if sys.platform != 'win32' and not sys.platform.startswith('java'):
         res = app.get('', expect_errors=True)
         assert res.status == 500
         assert 'error' in res
-        assert b'some data' in res.errors
-
+        assert 'some data' in res.errors


### PR DESCRIPTION
The current ErrorMiddleware raises this error on python 3

```
  File "/allura-data/virtualenv/lib/python3.6/site-packages/paste/exceptions/errormiddleware.py", line 188, in exception_handler
    simple_html_error=simple_html_error)
  File "/allura-data/virtualenv/lib/python3.6/site-packages/paste/exceptions/errormiddleware.py", line 391, in handle_exception
    error_stream.write(line)
  File "/allura-data/virtualenv/lib/python3.6/site-packages/gunicorn/http/wsgi.py", line 71, in write
    stream.write(data)
TypeError: write() argument must be str, not bytes
```

PEP-333 and PEP-3333 say that `wsgi.errors` is a text stream, so this changes ErrorMiddleware as well as the tests & other usage of `wsgi.errors` to no longer be bytes.  It also is a more complete fix for #18

Plus a `next()` change in ErrorMiddleware too.