### PR TITLE
Replace deprecated threading aliases

### DIFF
--- a/paste/httpserver.py
+++ b/paste/httpserver.py
@@ -764,7 +764,7 @@ class ThreadPool(object):
         worker = threading.Thread(target=self.worker_thread_callback,
                                   args=args, kwargs=kwargs,
                                   name=("worker %d" % index))
-        worker.setDaemon(self.daemon)
+        worker.daemon = self.daemon
         worker.start()
 
     def kill_hung_threads(self):
@@ -865,7 +865,7 @@ class ThreadPool(object):
                        ids="\n  ".join(map(str, found))),
                 subject="Process restart (too many zombie threads)")
             self.shutdown(10)
-            print('Shutting down', threading.currentThread())
+            print('Shutting down', threading.current_thread())
             raise ServerExit(3)
 
     def worker_thread_callback(self, message=None):
@@ -873,7 +873,7 @@ class ThreadPool(object):
         Worker thread should call this method to get and process queued
         callables.
         """
-        thread_obj = threading.currentThread()
+        thread_obj = threading.current_thread()
         thread_id = thread_obj.thread_id = _thread.get_ident()
         self.workers.append(thread_obj)
         self.idle_workers.append(thread_id)

--- a/paste/reloader.py
+++ b/paste/reloader.py
@@ -59,7 +59,7 @@ def install(poll_interval=1):
     """
     mon = Monitor(poll_interval=poll_interval)
     t = threading.Thread(target=mon.periodic_reload)
-    t.setDaemon(True)
+    t.daemon = True
     t.start()
 
 class Monitor(object):

--- a/paste/util/threadedprint.py
+++ b/paste/util/threadedprint.py
@@ -27,7 +27,7 @@ paramwriter
     called like ``paramwriter(thread_name, text)`` for every write.
 
 The thread name is the value returned by
-``threading.currentThread().getName()``, a string (typically something
+``threading.current_thread().name``, a string (typically something
 like Thread-N).
 
 You can also submit file-like objects for specific threads, which will
@@ -89,8 +89,8 @@ class PrintCatcher(filemixin.FileMixin):
         self._paramwriter = paramwriter
         self._catchers = {}
 
-    def write(self, v, currentThread=threading.currentThread):
-        name = currentThread().getName()
+    def write(self, v, currentThread=threading.current_thread):
+        name = current_thread().name
         catchers = self._catchers
         if not catchers.has_key(name):
             self._defaultfunc(name, v)
@@ -100,7 +100,7 @@ class PrintCatcher(filemixin.FileMixin):
 
     def seek(self, *args):
         # Weird, but Google App Engine is seeking on stdout
-        name = threading.currentThread().getName()
+        name = threading.current_thread().name
         catchers = self._catchers
         if not name in catchers:
             self._default.seek(*args)
@@ -108,7 +108,7 @@ class PrintCatcher(filemixin.FileMixin):
             catchers[name].seek(*args)
 
     def read(self, *args):
-        name = threading.currentThread().getName()
+        name = threading.current_thread().name
         catchers = self._catchers
         if not name in catchers:
             self._default.read(*args)
@@ -131,15 +131,15 @@ class PrintCatcher(filemixin.FileMixin):
             % name)
 
     def register(self, catcher, name=None,
-                 currentThread=threading.currentThread):
+                 currentThread=threading.current_thread):
         if name is None:
-            name = currentThread().getName()
+            name = currentThread().name
         self._catchers[name] = catcher
 
     def deregister(self, name=None,
-                   currentThread=threading.currentThread):
+                   currentThread=threading.current_thread):
         if name is None:
-            name = currentThread().getName()
+            name = currentThread().name
         assert self._catchers.has_key(name), (
             "There is no PrintCatcher catcher for the thread %r" % name)
         del self._catchers[name]
@@ -189,8 +189,8 @@ class StdinCatcher(filemixin.FileMixin):
         self._paramwriter = paramwriter
         self._catchers = {}
 
-    def read(self, size=None, currentThread=threading.currentThread):
-        name = currentThread().getName()
+    def read(self, size=None, currentThread=threading.current_thread):
+        name = currentThread().name
         catchers = self._catchers
         if not catchers.has_key(name):
             return self._defaultfunc(name, size)
@@ -213,15 +213,15 @@ class StdinCatcher(filemixin.FileMixin):
             % name)
 
     def register(self, catcher, name=None,
-                 currentThread=threading.currentThread):
+                 currentThread=threading.current_thread):
         if name is None:
-            name = currentThread().getName()
+            name = currentThread().name
         self._catchers[name] = catcher
 
     def deregister(self, catcher, name=None,
-                   currentThread=threading.currentThread):
+                   currentThread=threading.current_thread):
         if name is None:
-            name = currentThread().getName()
+            name = currentThread().name
         assert self._catchers.has_key(name), (
             "There is no StdinCatcher catcher for the thread %r" % name)
         del self._catchers[name]


### PR DESCRIPTION
`threading.currentThread`, `getName` and `setDaemon`  were deprecated in Python 3.10 (October 2021).

Replace with `threading.current_thread`, `name` and `daemon` added in Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174
