### PR TITLE
Fix py3 compatibility in paste.wsgilib.catch_errors

### DIFF
--- a/paste/wsgilib.py
+++ b/paste/wsgilib.py
@@ -209,7 +209,7 @@ class _wrap_app_iter(object):
 
     def next(self):
         try:
-            return self.app_iter.next()
+            return six.next(self.app_iter)
         except StopIteration:
             if self.ok_callback:
                 self.ok_callback()


### PR DESCRIPTION
A Python 3 application might only define `__next__`, not `next`.  Use
`six.next` instead.

This is very similar to https://github.com/cdent/paste/pull/53, and was
apparently missed there.

I ran into this while upgrading Launchpad to a development release of `loggerhead` (for bazaar.launchpad.net).  I haven't quite worked out why I didn't see this before, but at any rate it seems like a clear enough bug.