### PR TITLE
Add project URLs to PyPI listing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,11 @@ setup(name="Paste",
       author="Chris Dent",
       author_email="chris.dent@gmail.com",
       url="https://pythonpaste.readthedocs.io/",
+      project_urls={
+        "Source": "https://github.com/cdent/paste",
+        "Bug Tracker": "https://github.com/cdent/paste/issues",
+        "Documentation": "https://pythonpaste.readthedocs.io"
+      },
       license="MIT",
       packages=find_packages(exclude=['ez_setup', 'examples', 'packages', 'tests*']),
       package_data=finddata.find_package_data(


### PR DESCRIPTION
This adds the project's links to the PyPI sidebar, for easier access. For an example, see the [page for the `requests` library](https://pypi.org/project/requests/).

This was done by adding a dictionary, called `project_urls`, to the parameters of the setup function in `setup.py`.

Note that this change will not appear until the next release.