### PR TITLE
Test Python 3.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,6 +22,8 @@ jobs:
                       env: py310
                     - python: "3.11"
                       env: py311
+                    - python: "3.12-dev"
+                      env: py312
                     - python: pypy-3.8
                       env: pypy3
         name: ${{ matrix.env }} on Python ${{ matrix.python }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36, py37, py38, py39, pypy
+envlist = py{27, 36, 37, 38, 39, 310, 311, 312, py}
 
 [testenv]
 # For performance, but also for using "source" with coveragepy (https://github.com/nedbat/coveragepy/issues/268).


### PR DESCRIPTION
This is currently 3.12.0 alpha 7 which still has the imp module (re: https://github.com/cdent/paste/pull/76), but 3.12.0 beta 1 is due out in a week with the module removed.

https://peps.python.org/pep-0693/#release-schedule