### PR TITLE
Replace cgi.escape

### DIFF
--- a/paste/auth/open_id.py
+++ b/paste/auth/open_id.py
@@ -55,7 +55,7 @@ login.
 
 __all__ = ['AuthOpenIDHandler']
 
-import cgi
+import html
 import urlparse
 import re
 
@@ -63,7 +63,7 @@ import paste.request
 from paste import httpexceptions
 
 def quoteattr(s):
-    qs = cgi.escape(s, 1)
+    qs = html.escape(s)
     return '"%s"' % (qs,)
 
 # You may need to manually add the openid package into your
@@ -200,7 +200,7 @@ class AuthOpenIDHandler:
             else:
                 fmt = 'Could not find OpenID information in <q>%s</q>'
 
-            message = fmt % (cgi.escape(openid_url),)
+            message = fmt % (html.escape(openid_url),)
             return self.render(request, message, css_class='error', form_contents=openid_url)
         elif status == consumer.SUCCESS:
             # The URL was a valid identity URL. Now we construct a URL
@@ -245,7 +245,7 @@ class AuthOpenIDHandler:
             # message to help the user figure out what happened.
             openid_url = info
             fmt = "Verification of %s failed."
-            message = fmt % (cgi.escape(openid_url),)
+            message = fmt % (html.escape(openid_url),)
         elif status == consumer.SUCCESS:
             # Success means that the transaction completed without
             # error. If info is None, it means that the user cancelled
@@ -266,7 +266,7 @@ class AuthOpenIDHandler:
                     fmt = ("If you had supplied a login redirect path, you would have "
                            "been redirected there.  "
                            "You have successfully verified %s as your identity.")
-                    message = fmt % (cgi.escape(openid_url),)
+                    message = fmt % (html.escape(openid_url),)
                 else:
                     # @@: This stuff doesn't make sense to me; why not a remote redirect?
                     request['environ']['paste.auth.open_id'] = openid_url

--- a/paste/debug/doctest_webapp.py
+++ b/paste/debug/doctest_webapp.py
@@ -14,7 +14,7 @@ import os
 import sys
 import shutil
 import re
-import cgi
+import html
 import rfc822
 from io import StringIO
 from paste.util import PySourceColor
@@ -214,7 +214,7 @@ def show_file(path, version, description=None, data=None):
         html = ('<div class="source-code">%s</div>'
                 % PySourceColor.str2html(data, PySourceColor.dark))
     else:
-        html = '<pre class="source-code">%s</pre>' % cgi.escape(data, 1)
+        html = '<pre class="source-code">%s</pre>' % html.escape(data)
     html = '<span class="source-filename">%s</span><br>%s' % (
         description or path, html)
     write_data(resource_filename('%s.%s.gen.html' % (path, version)),

--- a/paste/debug/prints.py
+++ b/paste/debug/prints.py
@@ -19,7 +19,7 @@ necessary.
 
 from io import StringIO
 import re
-import cgi
+import html
 from paste.util import threadedprint
 from paste import wsgilib
 from paste import response
@@ -132,7 +132,7 @@ class PrintDebugMiddleware(object):
     def add_log(self, html, log):
         if not log:
             return html
-        text = cgi.escape(log)
+        text = html.escape(log)
         text = text.replace('\n', '<br>')
         text = text.replace('  ', '&nbsp; ')
         match = self._explicit_re.search(html)

--- a/paste/debug/profile.py
+++ b/paste/debug/profile.py
@@ -11,7 +11,7 @@ import os
 import hotshot
 import hotshot.stats
 import threading
-import cgi
+import html
 import time
 from io import StringIO
 from paste import response
@@ -78,7 +78,7 @@ class ProfileMiddleware(object):
             output_callers = capture_output(
                 stats.print_callers, self.limit)
             body += '<pre style="%s">%s\n%s</pre>' % (
-                self.style, cgi.escape(output), cgi.escape(output_callers))
+                self.style, html.escape(output), html.escape(output_callers))
             return [body]
         finally:
             self.lock.release()

--- a/paste/debug/watchthreads.py
+++ b/paste/debug/watchthreads.py
@@ -3,7 +3,6 @@ Watches the key ``paste.httpserver.thread_pool`` to see how many
 threads there are and report on any wedged threads.
 """
 import sys
-import cgi
 import time
 import traceback
 from io import StringIO

--- a/paste/debug/wdg_validate.py
+++ b/paste/debug/wdg_validate.py
@@ -9,7 +9,7 @@ from io import StringIO
 import subprocess
 from paste.response import header_value
 import re
-import cgi
+import html
 
 __all__ = ['WDGValidateMiddleware']
 
@@ -95,7 +95,7 @@ class WDGValidateMiddleware(object):
     def add_error(self, html_page, html_errors):
         add_text = ('<pre style="background-color: #ffd; color: #600; '
                     'border: 1px solid #000;">%s</pre>'
-                    % cgi.escape(html_errors))
+                    % html.escape(html_errors))
         match = self._end_body_regex.search(html_page)
         if match:
             return [html_page[:match.start()]

--- a/paste/exceptions/errormiddleware.py
+++ b/paste/exceptions/errormiddleware.py
@@ -6,7 +6,7 @@ Error handler middleware
 """
 import sys
 import traceback
-import cgi
+import html
 from io import StringIO
 from paste.exceptions import formatter, collector, reporter
 from paste import wsgilib
@@ -428,7 +428,7 @@ def send_report(rep, exc_data, html=True):
 
             <pre>%s</pre>
             </p>""" % (
-                cgi.escape(str(rep)), output.getvalue())
+                html.escape(str(rep)), output.getvalue())
         else:
             return (
                 "Additionally an error occurred while sending the "


### PR DESCRIPTION
cgi.escape was deprecated in Python 3.2 and was removed in Python 3.8.