### PR TITLE
Suppress deprecation warnings in tests (except cgi)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
+*.log
 *.pyc
-.tox
+
 .coverage
+.idea
+.pytest_cache
+.tox
+.venv
+.vscode
+
 *.egg-info
+
+build
+dist
 docs/_build/

--- a/paste/__init__.py
+++ b/paste/__init__.py
@@ -1,9 +1,14 @@
 # (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
 # Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
+
+import warnings
+
 try:
-    import pkg_resources
-    pkg_resources.declare_namespace(__name__)
-except ImportError:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        import pkg_resources
+        pkg_resources.declare_namespace(__name__)
+except (AttributeError, ImportError):
     # don't prevent use of paste if pkg_resources isn't installed
     from pkgutil import extend_path
     __path__ = extend_path(__path__, __name__)

--- a/paste/urlparser.py
+++ b/paste/urlparser.py
@@ -1,7 +1,7 @@
 # (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
 # Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 """
-WSGI applications that parses the URL and dispatches to on-disk resources
+WSGI applications that parse the URL and dispatch to on-disk resources
 """
 
 import os

--- a/paste/urlparser.py
+++ b/paste/urlparser.py
@@ -1,31 +1,35 @@
 # (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
 # Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 """
-WSGI applications that parse the URL and dispatch to on-disk resources
+WSGI applications that parses the URL and dispatches to on-disk resources
 """
 
 import os
 import sys
-import importlib.util as imputil
-
 import mimetypes
+import warnings
+import importlib.util as imputil
 try:
-    import pkg_resources
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=DeprecationWarning)
+        import pkg_resources
 except ImportError:
     pkg_resources = None
 from paste import request
 from paste import fileapp
 from paste.util import import_string
 from paste import httpexceptions
-from .httpheaders import ETAG
 from paste.util import converters
-
-class NoDefault(object):
-    pass
+from .httpheaders import ETAG
 
 __all__ = ['URLParser', 'StaticURLParser', 'PkgResourcesParser']
 
-class URLParser(object):
+
+class NoDefault:
+    pass
+
+
+class URLParser:
 
     """
     WSGI middleware

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,1 @@
-import sys
-import os
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-import pkg_resources
-pkg_resources.require('Paste')
+"""Tests for Paste"""

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -1,6 +1,7 @@
-from .test_errordocument import simple_app
+import pytest
 from paste.fixture import TestApp
 from paste.recursive import RecursiveMiddleware, ForwardRequestException
+from .test_errordocument import simple_app
 
 def error_docs_app(environ, start_response):
     if environ['PATH_INFO'] == '/not_found':
@@ -102,4 +103,6 @@ def test_ForwardRequestException():
             if environ['PATH_INFO'] != '/not_found':
                 return self.app(environ, start_response)
             raise ForwardRequestException(path_info=self.url)
-    forward(TestForwardRequestExceptionMiddleware(error_docs_app))
+
+    with pytest.warns(DeprecationWarning):
+        forward(TestForwardRequestExceptionMiddleware(error_docs_app))

--- a/tests/test_urlparser.py
+++ b/tests/test_urlparser.py
@@ -1,8 +1,12 @@
 import os
+import warnings
 
-from paste.urlparser import PkgResourcesParser, StaticURLParser, URLParser
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", category=DeprecationWarning)
+    from pkg_resources import get_distribution
+
 from paste.fixture import TestApp
-from pkg_resources import get_distribution
+from paste.urlparser import PkgResourcesParser, StaticURLParser, URLParser
 
 def relative_path(name):
     here = os.path.join(os.path.dirname(os.path.abspath(__file__)),


### PR DESCRIPTION
Suppress expected deprecation warnings during tests and when using urlparser.

This PR does not cover the deprecation of cgi and cgitb.