### PR TITLE
Clean up Python 2 styled code

### DIFF
--- a/docs/StyleGuide.txt
+++ b/docs/StyleGuide.txt
@@ -64,7 +64,7 @@ Python Style Guide.  Some things to take particular note of:
 
 * Docstrings are good.  They should look like::
 
-    class AClass(object):
+    class AClass:
         """
         doc string...
         """

--- a/docs/do-it-yourself-framework.txt
+++ b/docs/do-it-yourself-framework.txt
@@ -150,7 +150,7 @@ have to start with some root object, of course, which we'll pass in...
 
 ::
 
-    class ObjectPublisher(object):
+    class ObjectPublisher:
 
         def __init__(self, root):
             self.root = root
@@ -222,7 +222,7 @@ class into a module ``objectpub``::
 
     from objectpub import ObjectPublisher
 
-    class Root(object):
+    class Root:
 
         # The "index" method:
         def __call__(self):
@@ -260,12 +260,12 @@ request is a little slim.
     # insensitive keys:
     from paste.response import HeaderDict
 
-    class Request(object):
+    class Request:
         def __init__(self, environ):
             self.environ = environ
             self.fields = parse_formvars(environ)
 
-    class Response(object):
+    class Response:
         def __init__(self):
             self.headers = HeaderDict(
                 {'content-type': 'text/html'})
@@ -286,7 +286,7 @@ we'll attach the request and response objects here.
 So, let's remind ourselves of what the ``__call__`` function looked
 like::
 
-    class ObjectPublisher(object):
+    class ObjectPublisher:
         ...
 
         def __call__(self, environ, start_response):
@@ -301,7 +301,7 @@ Lets's update that::
     import threading
     webinfo = threading.local()
 
-    class ObjectPublisher(object):
+    class ObjectPublisher:
         ...
 
         def __call__(self, environ, start_response):
@@ -361,7 +361,7 @@ response).
 To give an example of a really really simple middleware, here's one
 that capitalizes the response::
 
-    class Capitalizer(object):
+    class Capitalizer:
 
         # We generally pass in the application to be wrapped to
         # the middleware constructor:
@@ -391,7 +391,7 @@ is a somewhat more thorough implementation of this.
 
        from webob import Request
 
-       class Capitalizer(object):
+       class Capitalizer:
            def __init__(self, app):
                self.app = app
            def __call__(self, environ, start_response):
@@ -402,7 +402,7 @@ is a somewhat more thorough implementation of this.
 
 So here's some code that does something useful, authentication::
 
-    class AuthMiddleware(object):
+    class AuthMiddleware:
 
         def __init__(self, wrap_app):
             self.wrap_app = wrap_app
@@ -450,7 +450,7 @@ So here's some code that does something useful, authentication::
 
        from webob import Request, Response
 
-       class AuthMiddleware(object):
+       class AuthMiddleware:
            def __init__(self, app):
                self.app = app
            def __call__(self, environ, start_response):

--- a/docs/url-parsing-with-wsgi.txt
+++ b/docs/url-parsing-with-wsgi.txt
@@ -69,7 +69,7 @@ request and responsibility for the response off to another object
 (another actor, really).  In the process we can actually retain some
 control -- we can capture and transform the response, and we can
 modify the request -- but that's not what the typical URL resolver will
-do.  
+do.
 
 Motivations
 ===========
@@ -80,7 +80,7 @@ Typically when a framework first supports WSGI or is integrated into
 Paste, it is "monolithic" with respect to URLs.  That is, you define
 (in Paste, or maybe in Apache) a "root" URL, and everything under that
 goes into the framework.  What the framework does internally, Paste
-does not know -- it probably finds internal objects to dispatch to, 
+does not know -- it probably finds internal objects to dispatch to,
 but the framework is opaque to Paste.  Not just to Paste, but to
 any code that isn't in that framework.
 
@@ -171,7 +171,7 @@ in turn may delegate to yet another application.
 
 Here's a very simple implementation of URLParser::
 
-    class URLParser(object):
+    class URLParser:
         def __init__(self, dir):
             self.dir = dir
         def __call__(self, environ, start_response):
@@ -217,7 +217,7 @@ handle it.  This "application" might be a URLParser or similar system
 
 ::
 
-    class GrabDate(object):
+    class GrabDate:
         def __init__(self, subapp):
             self.subapp = subapp
         def __call__(self, environ, start_response):
@@ -249,12 +249,12 @@ well -- it usually just means use ``getattr`` with the popped
 segments.  But we'll implement a rough approximation of `Quixote's
 <http://www.mems-exchange.org/software/quixote/>`_ URL parsing::
 
-    class ObjectApp(object):
+    class ObjectApp:
         def __init__(self, obj):
             self.obj = obj
         def __call__(self, environ, start_response):
             next = wsgilib.path_info_pop(environ)
-            if next is None: 
+            if next is None:
                 # This is the object, lets serve it...
                 return self.publish(obj, environ, start_response)
             next = next or '_q_index' # the default index method
@@ -288,7 +288,7 @@ Things to note:
   (when ``next`` is ``None``).  This means ``_q_traverse`` has to
   consume extra segments of the path.  In this version ``_q_traverse``
   is only given the next piece of the path; Quixote gives it the
-  entire path (as a list of segments).  
+  entire path (as a list of segments).
 
 * ``publish`` is really a small and lame way to turn a Quixote object
   into a WSGI application.  For any serious framework you'd want to do
@@ -298,7 +298,7 @@ Things to note:
   <http://www.python.org/peps/pep-0246.html>`_ to convert objects into
   applications.  This would include removing the explicit creation of
   new ``ObjectApp`` instances, which could also be a kind of fall-back
-  adaptation. 
+  adaptation.
 
 Anyway, this example is less complete, but maybe it will get you
 thinking.

--- a/paste/auth/auth_tkt.py
+++ b/paste/auth/auth_tkt.py
@@ -52,7 +52,7 @@ from paste import request
 DEFAULT_DIGEST = hashlib.md5
 
 
-class AuthTicket(object):
+class AuthTicket:
 
     """
     This class represents an authentication token.  You must pass in
@@ -221,7 +221,7 @@ def maybe_encode(s, encoding='utf8'):
     return s
 
 
-class AuthTKTMiddleware(object):
+class AuthTKTMiddleware:
 
     """
     Middleware that checks for signed cookies that match what

--- a/paste/auth/basic.py
+++ b/paste/auth/basic.py
@@ -31,7 +31,7 @@ from paste.httpheaders import (
     WWW_AUTHENTICATE,
 )
 
-class AuthBasicAuthenticator(object):
+class AuthBasicAuthenticator:
     """
     implements ``Basic`` authentication details
     """
@@ -59,7 +59,7 @@ class AuthBasicAuthenticator(object):
 
     __call__ = authenticate
 
-class AuthBasicHandler(object):
+class AuthBasicHandler:
     """
     HTTP/1.0 ``Basic`` authentication middleware
 

--- a/paste/auth/cookie.py
+++ b/paste/auth/cookie.py
@@ -79,7 +79,7 @@ def new_secret():
     secret = secret.encode('utf8')
     return secret
 
-class AuthCookieSigner(object):
+class AuthCookieSigner:
     """
     save/restore ``environ`` entries via digially signed cookie
 
@@ -195,7 +195,7 @@ class AuthCookieEnviron(list):
             return
         list.append(self, str(value))
 
-class AuthCookieHandler(object):
+class AuthCookieHandler:
     """
     the actual handler that should be put in your middleware stack
 

--- a/paste/auth/digest.py
+++ b/paste/auth/digest.py
@@ -78,7 +78,7 @@ def digest_password(realm, username, password):
     content = content.encode('utf8')
     return md5(content).hexdigest()
 
-class AuthDigestAuthenticator(object):
+class AuthDigestAuthenticator:
     """ implementation of RFC 2617 - HTTP Digest Authentication """
     def __init__(self, realm, authfunc):
         self.nonce    = {} # list to prevent replay attacks
@@ -164,7 +164,7 @@ class AuthDigestAuthenticator(object):
 
     __call__ = authenticate
 
-class AuthDigestHandler(object):
+class AuthDigestHandler:
     """
     middleware for HTTP Digest authentication (RFC 2617)
 

--- a/paste/auth/digest.py
+++ b/paste/auth/digest.py
@@ -54,7 +54,7 @@ def _split_auth_string(auth_string):
                 prev = "%s,%s" % (prev, item)
                 continue
         except AttributeError:
-            if prev == None:
+            if prev is None:
                 prev = item
                 continue
             else:

--- a/paste/auth/digest.py
+++ b/paste/auth/digest.py
@@ -156,7 +156,7 @@ class AuthDigestAuthenticator:
             if qop:
                 assert 'auth' == qop
                 assert nonce and nc
-        except:
+        except Exception:
             return self.build_authentication()
         ha1 = self.authfunc(environ, realm, username)
         return self.compute(ha1, username, response, method, authpath,

--- a/paste/auth/form.py
+++ b/paste/auth/form.py
@@ -44,7 +44,7 @@ TEMPLATE = """\
 </html>
 """
 
-class AuthFormHandler(object):
+class AuthFormHandler:
     """
     HTML-based login middleware
 

--- a/paste/auth/multi.py
+++ b/paste/auth/multi.py
@@ -32,7 +32,7 @@ serving on...
 
 """
 
-class MultiHandler(object):
+class MultiHandler:
     """
     Multiple Authentication Handler
 

--- a/paste/cascade.py
+++ b/paste/cascade.py
@@ -40,7 +40,7 @@ def make_cascade(loader, global_conf, catch='404', **local_conf):
     apps = [app for name, app in apps]
     return Cascade(apps, catch=catch)
 
-class Cascade(object):
+class Cascade:
 
     """
     Passed a list of applications, ``Cascade`` will try each of them

--- a/paste/cgiapp.py
+++ b/paste/cgiapp.py
@@ -116,7 +116,7 @@ class CGIApplication:
             start_response(writer.status, writer.headers)
         return []
 
-class CGIWriter(object):
+class CGIWriter:
 
     def __init__(self, environ, start_response):
         self.environ = environ

--- a/paste/cgitb_catcher.py
+++ b/paste/cgitb_catcher.py
@@ -62,7 +62,7 @@ class CgitbMiddleware:
             if not error_on_close and hasattr(app_iter, 'close'):
                 try:
                     app_iter.close()
-                except:
+                except Exception:
                     close_response = self.exception_handler(
                         sys.exc_info(), environ)
                     response += (

--- a/paste/cgitb_catcher.py
+++ b/paste/cgitb_catcher.py
@@ -10,26 +10,22 @@ Captures any exceptions and prints a pretty report.
 from io import StringIO
 import sys
 
-from paste.util import converters
+from paste.util import converters, NO_DEFAULT
 from paste.util.cgitb_hook import Hook
-
-
-class NoDefault:
-    ...
 
 
 class CgitbMiddleware:
 
     def __init__(self, app,
                  global_conf=None,
-                 display=NoDefault,
+                 display=NO_DEFAULT,
                  logdir=None,
                  context=5,
                  format="html"):
         self.app = app
         if global_conf is None:
             global_conf = {}
-        if display is NoDefault:
+        if display is NO_DEFAULT:
             display = global_conf.get('debug')
         if isinstance(display, str):
             display = converters.asbool(display)
@@ -88,7 +84,7 @@ class CgitbMiddleware:
 
 
 def make_cgitb_middleware(app, global_conf,
-                          display=NoDefault,
+                          display=NO_DEFAULT,
                           logdir=None,
                           context=5,
                           format='html'):
@@ -108,7 +104,7 @@ def make_cgitb_middleware(app, global_conf,
         source code
     """
     from paste.deploy.converters import asbool
-    if display is not NoDefault:
+    if display is not NO_DEFAULT:
         display = asbool(display)
     if 'debug' in global_conf:
         global_conf['debug'] = asbool(global_conf['debug'])

--- a/paste/config.py
+++ b/paste/config.py
@@ -2,7 +2,10 @@
 # Written for Paste (http://pythonpaste.org)
 # Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 """Paste Configuration Middleware and Objects"""
+
+from paste.util import NO_DEFAULT
 from paste.registry import RegistryManager, StackedObjectProxy
+
 
 __all__ = ['DispatchingConfig', 'CONFIG', 'ConfigMiddleware']
 
@@ -79,7 +82,7 @@ class DispatchingConfig(StackedObjectProxy):
 
 CONFIG = DispatchingConfig()
 
-no_config = object()
+
 class ConfigMiddleware(RegistryManager):
     """
     A WSGI middleware that adds a ``paste.config`` key (by default)
@@ -96,7 +99,7 @@ class ConfigMiddleware(RegistryManager):
         of the configuration `config`.
         """
         def register_config(environ, start_response):
-            popped_config = environ.get(environ_key, no_config)
+            popped_config = environ.get(environ_key, NO_DEFAULT)
             current_config = environ[environ_key] = config.copy()
             environ['paste.registry'].register(dispatching_config,
                                                current_config)
@@ -104,7 +107,7 @@ class ConfigMiddleware(RegistryManager):
             try:
                 app_iter = application(environ, start_response)
             finally:
-                if popped_config is no_config:
+                if popped_config is NO_DEFAULT:
                     environ.pop(environ_key, None)
                 else:
                     environ[environ_key] = popped_config

--- a/paste/cowbell/__init__.py
+++ b/paste/cowbell/__init__.py
@@ -6,7 +6,7 @@ from paste.response import header_value, remove_header
 
 SOUND = "http://www.c-eye.net/eyeon/WalkenWAVS/explorestudiospace.wav"
 
-class MoreCowbell(object):
+class MoreCowbell:
     def __init__(self, app):
         self.app = app
     def __call__(self, environ, start_response):

--- a/paste/debug/debugapp.py
+++ b/paste/debug/debugapp.py
@@ -12,7 +12,7 @@ import time
 __all__ = ['SimpleApplication', 'SlowConsumer']
 
 
-class SimpleApplication(object):
+class SimpleApplication:
     """
     Produces a simple web page
     """
@@ -22,7 +22,7 @@ class SimpleApplication(object):
                                   ('Content-Length', str(len(body)))])
         return [body]
 
-class SlowConsumer(object):
+class SlowConsumer:
     """
     Consumes an upload slowly...
 

--- a/paste/debug/fsdiff.py
+++ b/paste/debug/fsdiff.py
@@ -25,7 +25,7 @@ import re
 __all__ = ['Diff', 'Snapshot', 'File', 'Dir', 'report_expected_diffs',
            'show_diff']
 
-class Diff(object):
+class Diff:
 
     """
     Represents the difference between two snapshots
@@ -201,7 +201,7 @@ class Snapshot(IterableUserDict):
                               ignore_paths=self.ignore_paths,
                               ignore_hidden=self.ignore_hidden)
 
-class File(object):
+class File:
 
     """
     Represents a single file found as the result of a command.

--- a/paste/debug/prints.py
+++ b/paste/debug/prints.py
@@ -29,7 +29,7 @@ _threadedprint_installed = False
 
 __all__ = ['PrintDebugMiddleware']
 
-class TeeFile(object):
+class TeeFile:
 
     def __init__(self, files):
         self.files = files
@@ -38,7 +38,7 @@ class TeeFile(object):
         for file in self.files:
             file.write(v)
 
-class PrintDebugMiddleware(object):
+class PrintDebugMiddleware:
 
     """
     This middleware captures all the printed statements, and inlines

--- a/paste/debug/profile.py
+++ b/paste/debug/profile.py
@@ -167,7 +167,7 @@ class DecoratedProfile:
             start_time = time.time()
             try:
                 result = prof.runcall(func, *args, **kw)
-            except:
+            except Exception:
                 exc_info = sys.exc_info()
             end_time = time.time()
         finally:

--- a/paste/debug/profile.py
+++ b/paste/debug/profile.py
@@ -18,7 +18,7 @@ from paste import response
 
 __all__ = ['ProfileMiddleware', 'profile_decorator']
 
-class ProfileMiddleware(object):
+class ProfileMiddleware:
 
     """
     Middleware that profiles all requests.
@@ -139,7 +139,7 @@ def profile_decorator(**options):
         return replacement
     return decorator
 
-class DecoratedProfile(object):
+class DecoratedProfile:
 
     lock = threading.Lock()
 

--- a/paste/debug/watchthreads.py
+++ b/paste/debug/watchthreads.py
@@ -168,7 +168,7 @@ page_template = HTMLTemplate('''
 </html>
 ''', name='watchthreads.page_template')
 
-class WatchThreads(object):
+class WatchThreads:
 
     """
     Application that watches the threads in ``paste.httpserver``,

--- a/paste/debug/wdg_validate.py
+++ b/paste/debug/wdg_validate.py
@@ -13,7 +13,7 @@ import html
 
 __all__ = ['WDGValidateMiddleware']
 
-class WDGValidateMiddleware(object):
+class WDGValidateMiddleware:
 
     """
     Middleware that checks HTML and appends messages about the validity of

--- a/paste/errordocument.py
+++ b/paste/errordocument.py
@@ -182,7 +182,7 @@ class StatusBasedForward:
                 self.global_conf,
                 **self.params
             )
-            if not (new_url == None or isinstance(new_url, str)):
+            if not (new_url is None or isinstance(new_url, str)):
                 raise TypeError(
                     'Expected the url to internally '
                     'redirect to in the StatusBasedForward mapper'
@@ -311,7 +311,7 @@ class _StatusBasedRedirect:
                     self.global_conf,
                     self.kw
                 )
-                if not (new_url == None or isinstance(new_url, str)):
+                if not (new_url is None or isinstance(new_url, str)):
                     raise TypeError(
                         'Expected the url to internally '
                         'redirect to in the _StatusBasedRedirect error_mapper'

--- a/paste/errordocument.py
+++ b/paste/errordocument.py
@@ -60,7 +60,7 @@ def forward(app, codes):
         )
     )
 
-class StatusKeeper(object):
+class StatusKeeper:
     def __init__(self, app, status, url, headers):
         self.app = app
         self.status = status
@@ -94,7 +94,7 @@ class StatusKeeper(object):
             return [body]
 
 
-class StatusBasedForward(object):
+class StatusBasedForward:
     """
     Middleware that lets you test a response against a custom mapper object to
     programatically determine whether to internally forward to another URL and
@@ -254,7 +254,7 @@ def custom_forward(app, mapper, global_conf=None, **kw):
         global_conf = {}
     return _StatusBasedRedirect(app, mapper, global_conf, **kw)
 
-class _StatusBasedRedirect(object):
+class _StatusBasedRedirect:
     """
     Deprectated; use StatusBasedForward instead.
     """

--- a/paste/errordocument.py
+++ b/paste/errordocument.py
@@ -322,15 +322,15 @@ class _StatusBasedRedirect:
                 code_message.append([code, message])
                 return start_response(status, headers, exc_info)
             app_iter = self.application(environ, change_response)
-        except:
+        except Exception:
             try:
                 import sys
                 error = str(sys.exc_info()[1])
-            except:
+            except Exception:
                 error = ''
             try:
                 code, message = code_message[0]
-            except:
+            except Exception:
                 code, message = ['', '']
             environ['wsgi.errors'].write(
                 'Error occurred in _StatusBasedRedirect '

--- a/paste/evalexception/evalcontext.py
+++ b/paste/evalexception/evalcontext.py
@@ -38,7 +38,7 @@ class EvalContext:
                 debugger.set_continue()
             except KeyboardInterrupt:
                 raise
-            except:
+            except Exception:
                 traceback.print_exc(file=out)
                 debugger.set_continue()
         finally:

--- a/paste/evalexception/middleware.py
+++ b/paste/evalexception/middleware.py
@@ -84,7 +84,7 @@ def simplecatcher(application):
     def simplecatcher_app(environ, start_response):
         try:
             return application(environ, start_response)
-        except:
+        except Exception:
             out = StringIO()
             traceback.print_exc(file=out)
             start_response('500 Server Error',
@@ -301,7 +301,7 @@ class EvalException:
         def detect_start_response(status, headers, exc_info=None):
             try:
                 return start_response(status, headers, exc_info)
-            except:
+            except Exception:
                 raise
             else:
                 started.append(True)
@@ -314,7 +314,7 @@ class EvalException:
             finally:
                 if hasattr(app_iter, 'close'):
                     app_iter.close()
-        except:
+        except Exception:
             exc_info = sys.exc_info()
             for expected in environ.get('paste.expected_exceptions', []):
                 if isinstance(exc_info[1], expected):

--- a/paste/evalexception/middleware.py
+++ b/paste/evalexception/middleware.py
@@ -166,7 +166,7 @@ def get_debug_count(environ):
         environ['paste.evalexception.debug_count'] = _next = next(debug_counter)
         return _next
 
-class EvalException(object):
+class EvalException:
 
     def __init__(self, application, global_conf=None,
                  xmlhttp_key=None):
@@ -365,7 +365,7 @@ class EvalException(object):
             debug_mode=True,
             simple_html_error=simple_html_error)
 
-class DebugInfo(object):
+class DebugInfo:
 
     def __init__(self, counter, exc_info, exc_data, base_path,
                  environ, view_uri):

--- a/paste/exceptions/collector.py
+++ b/paste/exceptions/collector.py
@@ -34,7 +34,7 @@ FALLBACK_ENCODING = 'UTF-8'
 
 __all__ = ['collect_exception', 'ExceptionCollector']
 
-class ExceptionCollector(object):
+class ExceptionCollector:
 
     """
     Produces a data structure that can be used by formatters to
@@ -390,7 +390,7 @@ class ExceptionCollector(object):
 
 limit = 200
 
-class Bunch(object):
+class Bunch:
 
     """
     A generic container

--- a/paste/exceptions/collector.py
+++ b/paste/exceptions/collector.py
@@ -235,7 +235,7 @@ class ExceptionCollector:
         if revision is not None:
             try:
                 revision = str(revision).strip()
-            except:
+            except Exception:
                 revision = '???'
         return revision
 
@@ -299,7 +299,7 @@ class ExceptionCollector:
                 if data['supplement'].extra:
                     for key, value in data['supplement'].extra.items():
                         extra_data.setdefault(key, []).append(value)
-            except:
+            except Exception:
                 if DEBUG_EXCEPTION_FORMATTER:
                     out = StringIO()
                     traceback.print_exc(file=out)
@@ -311,7 +311,7 @@ class ExceptionCollector:
             tbi = locals.get('__traceback_info__', None)
             if tbi is not None:
                 data['traceback_info'] = str(tbi)
-        except:
+        except Exception:
             pass
 
         marker = []
@@ -321,7 +321,7 @@ class ExceptionCollector:
                 tbh = locals.get(name, globals.get(name, marker))
                 if tbh is not marker:
                     data[name[2:-2]] = tbh
-            except:
+            except Exception:
                 pass
 
         return data
@@ -373,7 +373,7 @@ class ExceptionCollector:
                 new_result = decorator(result)
                 if new_result is not None:
                     result = new_result
-            except:
+            except Exception:
                 pass
         return result
 
@@ -517,7 +517,7 @@ def collect_exception(t, v, tb, limit=None):
 
       try:
           blah blah
-      except:
+      except Exception:
           exc_data = collect_exception(*sys.exc_info())
     """
     return col.collectException(t, v, tb, limit=limit)

--- a/paste/exceptions/errormiddleware.py
+++ b/paste/exceptions/errormiddleware.py
@@ -140,7 +140,7 @@ class ErrorMiddleware:
             sr_checker = ResponseStartChecker(start_response)
             app_iter = self.application(environ, sr_checker)
             return self.make_catching_iter(app_iter, environ, sr_checker)
-        except:
+        except Exception:
             exc_info = sys.exc_info()
             try:
                 for expect in environ.get('paste.expected_exceptions', []):
@@ -227,7 +227,7 @@ class CatchingIter:
                 return close_response
             else:
                 raise StopIteration
-        except:
+        except Exception:
             self.closed = True
             close_response = self._close()
             exc_info = sys.exc_info()
@@ -260,7 +260,7 @@ class CatchingIter:
         try:
             self.app_iterable.close()
             return None
-        except:
+        except Exception:
             close_response = self.error_middleware.exception_handler(
                 sys.exc_info(), self.environ)
             return close_response
@@ -339,7 +339,7 @@ def handle_exception(exc_info, error_stream, html=True,
         from paste.exceptions.errormiddleware import handle_exception
         try:
             do stuff
-        except:
+        except Exception:
             handle_exception(
                 sys.exc_info(), sys.stderr, html=False, ...other config...)
 
@@ -419,7 +419,7 @@ def handle_exception(exc_info, error_stream, html=True,
 def send_report(rep, exc_data, html=True):
     try:
         rep.report(exc_data)
-    except:
+    except Exception:
         output = StringIO()
         traceback.print_exc(file=output)
         if html:

--- a/paste/exceptions/errormiddleware.py
+++ b/paste/exceptions/errormiddleware.py
@@ -14,12 +14,12 @@ from paste import request
 
 __all__ = ['ErrorMiddleware', 'handle_exception']
 
-class _NoDefault(object):
+class _NoDefault:
     def __repr__(self):
         return '<NoDefault>'
 NoDefault = _NoDefault()
 
-class ErrorMiddleware(object):
+class ErrorMiddleware:
 
     """
     Error handling middleware
@@ -185,7 +185,7 @@ class ErrorMiddleware(object):
             error_message=self.error_message,
             simple_html_error=simple_html_error)
 
-class ResponseStartChecker(object):
+class ResponseStartChecker:
     def __init__(self, start_response):
         self.start_response = start_response
         self.response_started = False
@@ -194,7 +194,7 @@ class ResponseStartChecker(object):
         self.response_started = True
         self.start_response(*args)
 
-class CatchingIter(object):
+class CatchingIter:
 
     """
     A wrapper around the application iterator that will catch
@@ -266,7 +266,7 @@ class CatchingIter(object):
             return close_response
 
 
-class Supplement(object):
+class Supplement:
 
     """
     This is a supplement used to display standard WSGI information in

--- a/paste/exceptions/formatter.py
+++ b/paste/exceptions/formatter.py
@@ -14,7 +14,7 @@ from paste.util import PySourceColor
 def html_quote(s):
     return html.escape(str(s), True)
 
-class AbstractFormatter(object):
+class AbstractFormatter:
 
     general_data_order = ['object', 'source_url']
 

--- a/paste/exceptions/formatter.py
+++ b/paste/exceptions/formatter.py
@@ -481,7 +481,7 @@ def str2html(src, strip=False, indent_subsequent=0,
         return _str2html(src, strip=strip,
                          indent_subsequent=indent_subsequent,
                          highlight_inner=highlight_inner)
-    except:
+    except Exception:
         return html_quote(src)
 
 def _str2html(src, strip=False, indent_subsequent=0,
@@ -495,7 +495,7 @@ def _str2html(src, strip=False, indent_subsequent=0,
         src = pre_re.sub('', src)
         src = re.sub(r'^[\n\r]{0,1}', '', src)
         src = re.sub(r'[\n\r]{0,1}$', '', src)
-    except:
+    except Exception:
         src = html_quote(orig_src)
     lines = src.splitlines()
     if len(lines) == 1:

--- a/paste/exceptions/reporter.py
+++ b/paste/exceptions/reporter.py
@@ -11,7 +11,7 @@ except ImportError:
     sslerror = None
 from paste.exceptions import formatter
 
-class Reporter(object):
+class Reporter:
 
     def __init__(self, **conf):
         for name, value in conf.items():

--- a/paste/fileapp.py
+++ b/paste/fileapp.py
@@ -39,7 +39,7 @@ BLOCK_SIZE = 4096 * 16
 
 __all__ = ['DataApp', 'FileApp', 'DirectoryApp', 'ArchiveStore']
 
-class DataApp(object):
+class DataApp:
     """
     Returns an application that will send content in a single chunk,
     this application has support for setting cache-control and for
@@ -258,7 +258,7 @@ class FileApp(DataApp):
         else:
             return _FileIter(file, size=content_length)
 
-class _FileIter(object):
+class _FileIter:
 
     def __init__(self, file, block_size=None, size=None):
         self.file = file
@@ -284,7 +284,7 @@ class _FileIter(object):
         self.file.close()
 
 
-class DirectoryApp(object):
+class DirectoryApp:
     """
     Returns an application that dispatches requests to corresponding FileApps based on PATH_INFO.
     FileApp instances are cached. This app makes sure not to serve any files that are not in a subdirectory.
@@ -315,7 +315,7 @@ class DirectoryApp(object):
         return app(environ, start_response)
 
 
-class ArchiveStore(object):
+class ArchiveStore:
     """
     Returns an application that serves up a DataApp for items requested
     in a given zip or tar archive.

--- a/paste/fixture.py
+++ b/paste/fixture.py
@@ -48,7 +48,7 @@ def tempnam_no_warning(*args):
     """
     return os.tempnam(*args)
 
-class NoDefault(object):
+class NoDefault:
     pass
 
 def sorted(l):
@@ -56,7 +56,7 @@ def sorted(l):
     l.sort()
     return l
 
-class Dummy_smtplib(object):
+class Dummy_smtplib:
 
     existing = None
 
@@ -97,7 +97,7 @@ class AppError(Exception):
     pass
 
 
-class TestApp(object):
+class TestApp:
 
     __test__ = False  # Ignore with pytest test collection.
 
@@ -479,7 +479,7 @@ class TestApp(object):
         return TestResponse(self, status, headers, body, errors,
                             total_time)
 
-class CaptureStdout(object):
+class CaptureStdout:
 
     def __init__(self, actual):
         self.captured = io.StringIO()
@@ -500,7 +500,7 @@ class CaptureStdout(object):
         return self.captured.getvalue()
 
 
-class TestResponse(object):
+class TestResponse:
 
     __test__ = False  # Ignore with pytest test collection.
 
@@ -888,7 +888,7 @@ class TestResponse(object):
         webbrowser.open_new(url)
 
 
-class TestRequest(object):
+class TestRequest:
 
     __test__ = False  # Ignore with pytest test collection.
 
@@ -925,7 +925,7 @@ class TestRequest(object):
         self.expect_errors = expect_errors
 
 
-class Form(object):
+class Form:
 
     """
     This object represents a form that has been found in a page.
@@ -1160,7 +1160,7 @@ def _parse_attrs(text):
         attrs[attr_name] = attr_body
     return attrs
 
-class Field(object):
+class Field:
 
     """
     Field object.
@@ -1329,7 +1329,7 @@ Field.classes['image'] = Submit
 ############################################################
 
 
-class TestFileEnvironment(object):
+class TestFileEnvironment:
 
     """
     This represents an environment in which files will be written, and
@@ -1521,7 +1521,7 @@ class TestFileEnvironment(object):
         f.close()
         return FoundFile(self.base_path, path)
 
-class ProcResult(object):
+class ProcResult:
 
     """
     Represents the results of running a command in
@@ -1600,7 +1600,7 @@ class ProcResult(object):
                     s.append(t)
         return '\n'.join(s)
 
-class FoundFile(object):
+class FoundFile:
 
     """
     Represents a single file found as the result of a command.
@@ -1660,7 +1660,7 @@ class FoundFile(object):
             self.__class__.__name__,
             self.base_path, self.path)
 
-class FoundDir(object):
+class FoundDir:
 
     """
     Represents a directory created by a command.

--- a/paste/fixture.py
+++ b/paste/fixture.py
@@ -20,13 +20,13 @@ import smtplib
 import shlex
 import re
 import subprocess
-from urllib.parse import urlencode
 from urllib import parse as urlparse
+from urllib.parse import urlencode
 from http.cookies import BaseCookie
 
-from paste import wsgilib
-from paste import lint
+from paste import lint, wsgilib
 from paste.response import HeaderDict
+from paste.util import NO_DEFAULT
 
 def ensure_binary(s):
     if isinstance(s, bytes):
@@ -47,9 +47,6 @@ def tempnam_no_warning(*args):
     security warning.
     """
     return os.tempnam(*args)
-
-class NoDefault:
-    pass
 
 def sorted(l):
     l = list(l)
@@ -586,7 +583,7 @@ class TestResponse:
             if form.id:
                 forms[form.id] = form
 
-    def header(self, name, default=NoDefault):
+    def header(self, name, default=NO_DEFAULT):
         """
         Returns the named header; an error if there is not exactly one
         matching header (unless you give a default -- always an error
@@ -600,7 +597,7 @@ class TestResponse:
                     % (name, found, value))
                 found = value
         if found is None:
-            if default is NoDefault:
+            if default is NO_DEFAULT:
                 raise KeyError(
                     "No header found: %r (from %s)"
                     % (name, ', '.join([n for n, v in self.headers])))
@@ -1089,13 +1086,13 @@ class Form:
             field = fields[index]
             field.value = value
 
-    def get(self, name, index=None, default=NoDefault):
+    def get(self, name, index=None, default=NO_DEFAULT):
         """
         Get the named/indexed field object, or ``default`` if no field
         is found.
         """
         fields = self.fields.get(name)
-        if fields is None and default is not NoDefault:
+        if fields is None and default is not NO_DEFAULT:
             return default
         if index is None:
             return self[name]

--- a/paste/flup_session.py
+++ b/paste/flup_session.py
@@ -25,10 +25,10 @@ flup_session = flup.middleware.session
 # store type and parameters
 store_cache = {}
 
-class NoDefault(object):
+class NoDefault:
     pass
 
-class SessionMiddleware(object):
+class SessionMiddleware:
 
     session_classes = {
         'memory': (flup_session.MemorySessionStore,

--- a/paste/flup_session.py
+++ b/paste/flup_session.py
@@ -16,17 +16,16 @@ cookies, and there's no way to delete a session except to clear its
 data.
 """
 
-from paste import httpexceptions
-from paste import wsgilib
+from paste import httpexceptions, wsgilib
+from paste.util import NO_DEFAULT
+
 import flup.middleware.session
+
 flup_session = flup.middleware.session
 
 # This is a dictionary of existing stores, keyed by a tuple of
 # store type and parameters
 store_cache = {}
-
-class NoDefault:
-    pass
 
 class SessionMiddleware:
 
@@ -45,12 +44,12 @@ class SessionMiddleware:
 
     def __init__(self, app,
                  global_conf=None,
-                 session_type=NoDefault,
-                 cookie_name=NoDefault,
+                 session_type=NO_DEFAULT,
+                 cookie_name=NO_DEFAULT,
                  **store_config
                  ):
         self.application = app
-        if session_type is NoDefault:
+        if session_type is NO_DEFAULT:
             session_type = global_conf.get('session_type', 'disk')
         self.session_type = session_type
         try:
@@ -65,7 +64,7 @@ class SessionMiddleware:
             value = coercer(store_config.get(config_name, default))
             kw[kw_name] = value
         self.store = self.store_class(**kw)
-        if cookie_name is NoDefault:
+        if cookie_name is NO_DEFAULT:
             cookie_name = global_conf.get('session_cookie', '_SID_')
         self.cookie_name = cookie_name
 
@@ -94,8 +93,8 @@ class SessionMiddleware:
         return wsgilib.add_close(app_iter, service.close)
 
 def make_session_middleware(app, global_conf,
-                            session_type=NoDefault,
-                            cookie_name=NoDefault,
+                            session_type=NO_DEFAULT,
+                            cookie_name=NO_DEFAULT,
                             **store_config):
     """
     Wraps the application in a session-managing middleware.

--- a/paste/flup_session.py
+++ b/paste/flup_session.py
@@ -86,7 +86,7 @@ class SessionMiddleware:
             e.headers = dict(headers)
             service.close()
             raise
-        except:
+        except Exception:
             service.close()
             raise
 

--- a/paste/gzipper.py
+++ b/paste/gzipper.py
@@ -16,10 +16,10 @@ import io
 from paste.response import header_value, remove_header
 from paste.httpheaders import CONTENT_LENGTH
 
-class GzipOutput(object):
+class GzipOutput:
     pass
 
-class middleware(object):
+class middleware:
 
     def __init__(self, application, compress_level=6):
         self.application = application
@@ -41,7 +41,7 @@ class middleware(object):
 
         return response.write()
 
-class GzipResponse(object):
+class GzipResponse:
 
     def __init__(self, start_response, compress_level):
         self.start_response = start_response

--- a/paste/httpexceptions.py
+++ b/paste/httpexceptions.py
@@ -603,7 +603,7 @@ def get_exception(code):
 ## Middleware implementation:
 ############################################################
 
-class HTTPExceptionHandler(object):
+class HTTPExceptionHandler:
     """
     catches exceptions and turns them into proper HTTP responses
 

--- a/paste/httpheaders.py
+++ b/paste/httpheaders.py
@@ -170,7 +170,7 @@ for _name, _obj in dict(globals()).items():
 
 _headers = {}
 
-class HTTPHeader(object):
+class HTTPHeader:
     """
     an HTTP header
 
@@ -1008,7 +1008,7 @@ class _Authorization(_SingleValueHeader):
         auth.add_password(realm, path, username, password)
         (token, challenge) = challenge.split(' ', 1)
         chal = parse_keqv_list(parse_http_list(challenge))
-        class FakeRequest(object):
+        class FakeRequest:
             @property
             def full_url(self):
                 return path

--- a/paste/httpserver.py
+++ b/paste/httpserver.py
@@ -54,7 +54,7 @@ def _get_headers(headers, k):
         return headers.getheaders(k)  # Python 2 - mimetools.Message
 
 
-class ContinueHook(object):
+class ContinueHook:
     """
     When a client request includes a 'Expect: 100-continue' header, then
     it is the responsibility of the server to send 100 Continue when it
@@ -346,7 +346,7 @@ except ImportError:
                 self.socket.listen(request_queue_size)
 else:
 
-    class _ConnFixer(object):
+    class _ConnFixer:
         """ wraps a socket connection so it implements makefile """
         def __init__(self, conn):
             self.__conn = conn
@@ -466,7 +466,7 @@ class WSGIHandler(WSGIHandlerMixin, BaseHTTPRequestHandler):
         """
         return ''
 
-class LimitedLengthFile(object):
+class LimitedLengthFile:
     def __init__(self, file, length):
         self.file = file
         self.length = length
@@ -528,7 +528,7 @@ class LimitedLengthFile(object):
                 pass
         return self._consumed
 
-class ThreadPool(object):
+class ThreadPool:
     """
     Generic thread pool with a queue of callables to consume.
 
@@ -1044,7 +1044,7 @@ class ThreadPool(object):
         server.quit()
         print('email sent to', error_emails, message)
 
-class ThreadPoolMixIn(object):
+class ThreadPoolMixIn:
     """
     Mix-in class to process requests from a thread pool
     """

--- a/paste/httpserver.py
+++ b/paste/httpserver.py
@@ -313,7 +313,7 @@ class WSGIHandlerMixin:
         except socket.error as exce:
             self.wsgi_connection_drop(exce, environ)
             return
-        except:
+        except Exception:
             if not self.wsgi_headers_sent:
                 error_msg = "Internal Server Error\n"
                 self.wsgi_curr_headers = (
@@ -800,7 +800,7 @@ class ThreadPool:
                 try:
                     import pprint
                     info_desc = pprint.pformat(info)
-                except:
+                except Exception:
                     out = io.StringIO()
                     traceback.print_exc(file=out)
                     info_desc = 'Error:\n%s' % out.getvalue()
@@ -899,7 +899,7 @@ class ThreadPool:
                 try:
                     try:
                         runnable()
-                    except:
+                    except Exception:
                         # We are later going to call sys.exc_clear(),
                         # removing all remnants of any exception, so
                         # we should log it now.  But ideally no
@@ -1018,7 +1018,7 @@ class ThreadPool:
             ]
         try:
             system = ' '.join(os.uname())
-        except:
+        except Exception:
             system = '(unknown)'
         body = (
             "An error has occurred in the paste.httpserver.ThreadPool\n"

--- a/paste/lint.py
+++ b/paste/lint.py
@@ -176,7 +176,7 @@ def middleware(application, global_conf=None):
 
     return lint_app
 
-class InputWrapper(object):
+class InputWrapper:
 
     def __init__(self, wsgi_input):
         self.input = wsgi_input
@@ -210,7 +210,7 @@ class InputWrapper(object):
     def close(self):
         assert 0, "input.close() must not be called"
 
-class ErrorWrapper(object):
+class ErrorWrapper:
 
     def __init__(self, wsgi_errors):
         self.errors = wsgi_errors
@@ -229,7 +229,7 @@ class ErrorWrapper(object):
     def close(self):
         assert 0, "errors.close() must not be called"
 
-class WriteWrapper(object):
+class WriteWrapper:
 
     def __init__(self, wsgi_writer):
         self.writer = wsgi_writer
@@ -238,7 +238,7 @@ class WriteWrapper(object):
         assert isinstance(s, bytes)
         self.writer(s)
 
-class PartialIteratorWrapper(object):
+class PartialIteratorWrapper:
 
     def __init__(self, wsgi_iterator):
         self.iterator = wsgi_iterator
@@ -247,7 +247,7 @@ class PartialIteratorWrapper(object):
         # We want to make sure __iter__ is called
         return IteratorWrapper(self.iterator)
 
-class IteratorWrapper(object):
+class IteratorWrapper:
 
     def __init__(self, wsgi_iterator, check_start_response):
         self.original_iterator = wsgi_iterator

--- a/paste/modpython.py
+++ b/paste/modpython.py
@@ -57,7 +57,7 @@ except:
     pass
 from paste.deploy import loadapp
 
-class InputWrapper(object):
+class InputWrapper:
 
     def __init__(self, req):
         self.req = req
@@ -83,7 +83,7 @@ class InputWrapper(object):
             line = self.readline()
 
 
-class ErrorWrapper(object):
+class ErrorWrapper:
 
     def __init__(self, req):
         self.req = req
@@ -102,7 +102,7 @@ bad_value = ("You must provide a PythonOption '%s', either 'on' or 'off', "
              "when running a version of mod_python < 3.1")
 
 
-class Handler(object):
+class Handler:
 
     def __init__(self, req):
         self.started = False

--- a/paste/modpython.py
+++ b/paste/modpython.py
@@ -1,4 +1,4 @@
-"""WSGI Paste wrapper for mod_python. Requires Python 2.2 or greater.
+"""WSGI Paste wrapper for mod_python.
 
 
 Example httpd.conf section for a Paste app with an ini file::
@@ -53,8 +53,8 @@ import traceback
 
 try:
     from mod_python import apache
-except:
-    pass
+except ImportError:
+    apache = None
 from paste.deploy import loadapp
 
 class InputWrapper:
@@ -163,7 +163,7 @@ class Handler:
                 self.request.set_content_length(0)
             if hasattr(result, 'close'):
                 result.close()
-        except:
+        except Exception:
             traceback.print_exc(None, self.environ['wsgi.errors'])
             if not self.started:
                 self.request.status = 500

--- a/paste/pony.py
+++ b/paste/pony.py
@@ -25,7 +25,7 @@ lGtPZecIGJWW6oL2hpbWRZEkChe8eg5Wb7xx/MBZBFjxeZPEss+mRQ3Uhc8WQv684seSRO7i3nb4
 """
 
 
-class PonyMiddleware(object):
+class PonyMiddleware:
 
     def __init__(self, application):
         self.application = application

--- a/paste/progress.py
+++ b/paste/progress.py
@@ -40,7 +40,7 @@ ENVIRON_RECEIVED  = 'paste.bytes_received'
 REQUEST_STARTED   = 'paste.request_started'
 REQUEST_FINISHED  = 'paste.request_finished'
 
-class _ProgressFile(object):
+class _ProgressFile:
     """
     This is the input-file wrapper used to record the number of
     ``paste.bytes_received`` for the given request.
@@ -77,7 +77,7 @@ class _ProgressFile(object):
         self._ProgressFile_environ[ENVIRON_RECEIVED] += len(chunk)
         return chunk
 
-class UploadProgressMonitor(object):
+class UploadProgressMonitor:
     """
     monitors and reports on the status of uploads in progress
 
@@ -154,7 +154,7 @@ class UploadProgressMonitor(object):
     def uploads(self):
         return self.monitor
 
-class UploadProgressReporter(object):
+class UploadProgressReporter:
     """
     reports on the progress of uploads for a given user
 

--- a/paste/proxy.py
+++ b/paste/proxy.py
@@ -49,7 +49,7 @@ filtered_headers = (
     'upgrade',
 )
 
-class Proxy(object):
+class Proxy:
 
     def __init__(self, address, allowed_request_methods=(),
                  suppress_http_headers=()):
@@ -154,7 +154,7 @@ def make_proxy(global_conf, address, allowed_request_methods="",
         suppress_http_headers=suppress_http_headers)
 
 
-class TransparentProxy(object):
+class TransparentProxy:
 
     """
     A proxy that sends the request just as it was given, including

--- a/paste/recursive.py
+++ b/paste/recursive.py
@@ -33,7 +33,7 @@ class RecursionLoop(AssertionError):
     # Subclasses AssertionError for legacy reasons
     """Raised when a recursion enters into a loop"""
 
-class CheckForRecursionMiddleware(object):
+class CheckForRecursionMiddleware:
     def __init__(self, app, env):
         self.app = app
         self.env = env
@@ -50,7 +50,7 @@ class CheckForRecursionMiddleware(object):
         old_path_info.append(self.env.get('PATH_INFO', ''))
         return self.app(environ, start_response)
 
-class RecursiveMiddleware(object):
+class RecursiveMiddleware:
 
     """
     A WSGI middleware that allows for recursive and forwarded calls.
@@ -205,7 +205,7 @@ class ForwardRequestException(Exception):
             self.path_info = url
 
         # Base middleware
-        class ForwardRequestExceptionMiddleware(object):
+        class ForwardRequestExceptionMiddleware:
             def __init__(self, app):
                 self.app = app
 
@@ -238,7 +238,7 @@ class ForwardRequestException(Exception):
         else:
             self.factory = factory
 
-class Recursive(object):
+class Recursive:
 
     def __init__(self, application, environ, start_response):
         self.application = application
@@ -333,7 +333,7 @@ class Includer(Recursive):
         response.close()
         return response
 
-class IncludedResponse(object):
+class IncludedResponse:
 
     def __init__(self):
         self.headers = None
@@ -381,7 +381,7 @@ class IncluderAppIter(Recursive):
         response.app_iter = app_iter
         return response
 
-class IncludedAppIterResponse(object):
+class IncludedAppIterResponse:
 
     def __init__(self):
         self.status = None

--- a/paste/registry.py
+++ b/paste/registry.py
@@ -87,14 +87,13 @@ cases, and requires incredibly large amounts of proxy object access before
 one should consider the proxy object to be causing slow-downs. This section
 is provided solely in the extremely rare case that it is an issue so that a
 quick way to work around it is documented.
-
 """
+
+from paste.util import NO_DEFAULT
 import paste.util.threadinglocal as threadinglocal
 
 __all__ = ['StackedObjectProxy', 'RegistryManager', 'StackedObjectRestorer',
            'restorer']
-
-class NoDefault: pass
 
 class StackedObjectProxy:
     """Track an object instance internally using a stack
@@ -108,7 +107,7 @@ class StackedObjectProxy:
     objects can be removed with _pop_object.
 
     """
-    def __init__(self, default=NoDefault, name="Default"):
+    def __init__(self, default=NO_DEFAULT, name="Default"):
         """Create a new StackedObjectProxy
 
         If a default is given, its used in every thread if no other object
@@ -117,7 +116,7 @@ class StackedObjectProxy:
         """
         self.__dict__['____name__'] = name
         self.__dict__['____local__'] = threadinglocal.local()
-        if default is not NoDefault:
+        if default is not NO_DEFAULT:
             self.__dict__['____default_object__'] = default
 
     def __dir__(self):
@@ -190,8 +189,8 @@ class StackedObjectProxy:
         if objects:
             return objects[-1]
         else:
-            obj = self.__dict__.get('____default_object__', NoDefault)
-            if obj is not NoDefault:
+            obj = self.__dict__.get('____default_object__', NO_DEFAULT)
+            if obj is not NO_DEFAULT:
                 return obj
             else:
                 raise TypeError(

--- a/paste/registry.py
+++ b/paste/registry.py
@@ -394,7 +394,7 @@ class RegistryManager:
                     restorer.save_registry_state(environ)
             reg.cleanup()
             raise
-        except:
+        except Exception:
             # Save state for EvalException if it's present
             if environ.get('paste.evalexception'):
                 restorer.save_registry_state(environ)
@@ -425,7 +425,7 @@ class RegistryManager:
                     restorer.save_registry_state(environ)
             reg.cleanup()
             raise
-        except:
+        except Exception:
             # Save state for EvalException if it's present
             if environ.get('paste.evalexception'):
                 restorer.save_registry_state(environ)

--- a/paste/registry.py
+++ b/paste/registry.py
@@ -34,7 +34,7 @@ Example:
     app = RegistryManager(yourapp)
 
     #inside your wsgi app
-    class yourapp(object):
+    class yourapp:
         def __call__(self, environ, start_response):
             obj = someobject  # The request-local object you want to access
                               # via yourpackage.myglobal
@@ -94,9 +94,9 @@ import paste.util.threadinglocal as threadinglocal
 __all__ = ['StackedObjectProxy', 'RegistryManager', 'StackedObjectRestorer',
            'restorer']
 
-class NoDefault(object): pass
+class NoDefault: pass
 
-class StackedObjectProxy(object):
+class StackedObjectProxy:
     """Track an object instance internally using a stack
 
     The StackedObjectProxy proxies access to an object internally using a
@@ -277,7 +277,7 @@ class StackedObjectProxy(object):
         ('%s\n(StackedObjectRestorer restoration enabled)' % \
          _pop_object.__doc__)
 
-class Registry(object):
+class Registry:
     """Track objects and stacked object proxies for removal
 
     The Registry object is instantiated a single time for the request no
@@ -351,7 +351,7 @@ class Registry(object):
             stacked._pop_object(obj)
         self.reglist.pop()
 
-class RegistryManager(object):
+class RegistryManager:
     """Creates and maintains a Registry context
 
     RegistryManager creates a new registry context for the registration of
@@ -436,7 +436,7 @@ class RegistryManager(object):
             reg.cleanup()
 
 
-class StackedObjectRestorer(object):
+class StackedObjectRestorer:
     """Track StackedObjectProxies and their proxied objects for automatic
     restoration within EvalException's interactive debugger.
 

--- a/paste/reloader.py
+++ b/paste/reloader.py
@@ -61,7 +61,7 @@ def install(poll_interval=1):
     t.daemon = True
     t.start()
 
-class Monitor(object):
+class Monitor:
 
     instances = []
     global_extra_files = []

--- a/paste/reloader.py
+++ b/paste/reloader.py
@@ -92,7 +92,7 @@ class Monitor:
         for file_callback in self.file_callbacks:
             try:
                 filenames.extend(file_callback())
-            except:
+            except Exception:
                 print("Error calling paste.reloader callback %r:" % file_callback,
                       file=sys.stderr)
                 traceback.print_exc()

--- a/paste/session.py
+++ b/paste/session.py
@@ -76,7 +76,7 @@ class SessionMiddleware:
         return wsgilib.add_start_close(app_iter, start, close)
 
 
-class SessionFactory(object):
+class SessionFactory:
 
 
     def __init__(self, environ, cookie_name='_SID_',
@@ -175,7 +175,7 @@ last_cleanup = None
 cleaning_up = False
 cleanup_cycle = datetime.timedelta(seconds=15*60) #15 min
 
-class FileSession(object):
+class FileSession:
 
     def __init__(self, sid, create=False, session_file_path=tempfile.gettempdir(),
                  chmod=None,
@@ -279,7 +279,7 @@ class FileSession(object):
                     cleaning_up = False
                     raise
 
-class _NoDefault(object):
+class _NoDefault:
     def __repr__(self):
         return '<dynamic default>'
 NoDefault = _NoDefault()

--- a/paste/session.py
+++ b/paste/session.py
@@ -272,7 +272,7 @@ class FileSession:
                     last_cleanup = now
                     t = threading.Thread(target=self._clean_up)
                     t.start()
-                except:
+                except Exception:
                     # Normally _clean_up should set cleaning_up
                     # to false, but if something goes wrong starting
                     # it...

--- a/paste/session.py
+++ b/paste/session.py
@@ -39,8 +39,8 @@ try:
     from hashlib import md5
 except ImportError:
     from md5 import md5
-from paste import wsgilib
-from paste import request
+from paste import request, wsgilib
+from paste.util import NO_DEFAULT
 
 class SessionMiddleware:
 
@@ -279,18 +279,14 @@ class FileSession:
                     cleaning_up = False
                     raise
 
-class _NoDefault:
-    def __repr__(self):
-        return '<dynamic default>'
-NoDefault = _NoDefault()
 
 def make_session_middleware(
     app, global_conf,
-    session_expiration=NoDefault,
-    expiration=NoDefault,
-    cookie_name=NoDefault,
-    session_file_path=NoDefault,
-    chmod=NoDefault):
+    session_expiration=NO_DEFAULT,
+    expiration=NO_DEFAULT,
+    cookie_name=NO_DEFAULT,
+    session_file_path=NO_DEFAULT,
+    chmod=NO_DEFAULT):
     """
     Adds a middleware that handles sessions for your applications.
     The session is a peristent dictionary.  To get this dictionary
@@ -321,17 +317,17 @@ def make_session_middleware(
     Each of these also takes from the global configuration.  cookie_name
     and chmod take from session_cookie_name and session_chmod
     """
-    if session_expiration is NoDefault:
+    if session_expiration is NO_DEFAULT:
         session_expiration = global_conf.get('session_expiration', 60*12)
     session_expiration = int(session_expiration)
-    if expiration is NoDefault:
+    if expiration is NO_DEFAULT:
         expiration = global_conf.get('expiration', 60*48)
     expiration = int(expiration)
-    if cookie_name is NoDefault:
+    if cookie_name is NO_DEFAULT:
         cookie_name = global_conf.get('session_cookie_name', '_SID_')
-    if session_file_path is NoDefault:
+    if session_file_path is NO_DEFAULT:
         session_file_path = global_conf.get('session_file_path', '/tmp')
-    if chmod is NoDefault:
+    if chmod is NO_DEFAULT:
         chmod = global_conf.get('session_chmod', None)
     return SessionMiddleware(
         app, session_expiration=session_expiration,

--- a/paste/transaction.py
+++ b/paste/transaction.py
@@ -96,7 +96,7 @@ def BasicTransactionHandler(application, factory):
             else:
                 try:
                     conn.rollback()
-                except:
+                except Exception:
                     # TODO: check if rollback has already happened
                     return
             conn.close()

--- a/paste/transaction.py
+++ b/paste/transaction.py
@@ -16,7 +16,7 @@ two-phase commit goodness that I don't need.
 from paste.httpexceptions import HTTPException
 from wsgilib import catch_errors
 
-class TransactionManagerMiddleware(object):
+class TransactionManagerMiddleware:
 
     def __init__(self, application):
         self.application = application
@@ -29,7 +29,7 @@ class TransactionManagerMiddleware(object):
                             error_callback=manager.error,
                             ok_callback=manager.finish)
 
-class Manager(object):
+class Manager:
 
     def __init__(self):
         self.aborted = False
@@ -50,7 +50,7 @@ class Manager(object):
                 trans.commit()
 
 
-class ConnectionFactory(object):
+class ConnectionFactory:
     """
     Provides a callable interface for connecting to ADBAPI databases in
     a WSGI style (using the environment).  More advanced connection

--- a/paste/urlmap.py
+++ b/paste/urlmap.py
@@ -213,7 +213,7 @@ class URLMap(DictMixin):
         return self.not_found_application(environ, start_response)
 
 
-class PathProxyURLMap(object):
+class PathProxyURLMap:
 
     """
     This is a wrapper for URLMap that catches any strings that

--- a/paste/urlparser.py
+++ b/paste/urlparser.py
@@ -19,14 +19,10 @@ from paste import request
 from paste import fileapp
 from paste.util import import_string
 from paste import httpexceptions
-from paste.util import converters
+from paste.util import converters, NO_DEFAULT
 from .httpheaders import ETAG
 
 __all__ = ['URLParser', 'StaticURLParser', 'PkgResourcesParser']
-
-
-class NoDefault:
-    pass
 
 
 class URLParser:
@@ -84,15 +80,15 @@ class URLParser:
     parsers_by_directory = {}
 
     # This is lazily initialized
-    init_module = NoDefault
+    init_module = NO_DEFAULT
 
     global_constructors = {}
 
     def __init__(self, global_conf,
                  directory, base_python_name,
-                 index_names=NoDefault,
-                 hide_extensions=NoDefault,
-                 ignore_extensions=NoDefault,
+                 index_names=NO_DEFAULT,
+                 hide_extensions=NO_DEFAULT,
+                 ignore_extensions=NO_DEFAULT,
                  constructors=None,
                  **constructor_conf):
         """
@@ -115,15 +111,15 @@ class URLParser:
         self.base_python_name = base_python_name
         # This logic here should be deprecated since it is in
         # make_url_parser
-        if index_names is NoDefault:
+        if index_names is NO_DEFAULT:
             index_names = global_conf.get(
                 'index_names', ('index', 'Index', 'main', 'Main'))
         self.index_names = converters.aslist(index_names)
-        if hide_extensions is NoDefault:
+        if hide_extensions is NO_DEFAULT:
             hide_extensions = global_conf.get(
                 'hide_extensions', ('.pyc', '.bak', '.py~', '.pyo'))
         self.hide_extensions = converters.aslist(hide_extensions)
-        if ignore_extensions is NoDefault:
+        if ignore_extensions is NO_DEFAULT:
             ignore_extensions = global_conf.get(
                 'ignore_extensions', ())
         self.ignore_extensions = converters.aslist(ignore_extensions)
@@ -144,7 +140,7 @@ class URLParser:
 
     def __call__(self, environ, start_response):
         environ['paste.urlparser.base_python_name'] = self.base_python_name
-        if self.init_module is NoDefault:
+        if self.init_module is NO_DEFAULT:
             self.init_module = self.find_init_module(environ)
         path_info = environ.get('PATH_INFO', '')
         if not path_info:

--- a/paste/urlparser.py
+++ b/paste/urlparser.py
@@ -421,7 +421,7 @@ def make_py(parser, environ, filename):
 
 URLParser.register_constructor('.py', make_py)
 
-class StaticURLParser(object):
+class StaticURLParser:
     """
     Like ``URLParser`` but only serves static files.
 

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -924,7 +924,7 @@ def str2css(sourcestring, colors=None, title='',
               linenumbers=0, form=None):
     """Converts a code string to colorized CSS/HTML. Returns CSS/HTML string
 
-       If form != None then this will return (stylesheet_str, code_str)
+       If form is not None then this will return (stylesheet_str, code_str)
        colors=null,mono,lite,dark,dark2,idle,or pythonwin
     """
     if markup.lower() not in ['css' ,'xhtml']:
@@ -936,7 +936,7 @@ def str2css(sourcestring, colors=None, title='',
                    linenumbers=linenumbers)
     parse.format(form)
     stringIO.seek(0)
-    if form != None:
+    if form is not None:
         return parse._sendCSSStyle(external=1), stringIO.read()
     else:
         return None, stringIO.read()
@@ -969,7 +969,7 @@ def str2file(sourcestring, outfile, colors=None, title='',
     f.writelines(html)
     f.close()
     #write css
-    if css != None and dosheet:
+    if css is not None and dosheet:
         dir = os.path.dirname(outfile)
         outcss = os.path.join(dir,'pystyle.css')
         f = open(outcss,'wt')
@@ -1014,9 +1014,9 @@ def convert(source, outdir=None, colors=None,
     # Then we need to colorize them with path2file
     else:
         fileList = walkdir(source)
-        if fileList != None:
+        if fileList is not None:
             # make sure outdir is a dir
-            if outdir != None:
+            if outdir is not None:
                 if os.path.splitext(outdir)[1] != '':
                     outdir = os.path.split(outdir)[0]
             for item in fileList:
@@ -1032,7 +1032,7 @@ def path2file(sourcePath, out=None, colors=None, show=0,
                 header=None, footer=None, linenumbers=0, count=1):
     """ Converts python source to html file"""
     # If no outdir is given we use the sourcePath
-    if out == None:#this is a guess
+    if out is None:#this is a guess
         htmlPath = sourcePath + '.html'
     else:
         # If we do give an out_dir, and it does
@@ -1107,7 +1107,7 @@ def pageconvert(path, out=None, colors=lite, markup='xhtml', linenumbers=0,
 
        that is written in a webpage enclosed in tags.
     """
-    if out == None:
+    if out is None:
         out = os.path.dirname(path)
     infile = open(path, 'r').read()
     css,page  = tagreplace(sourcestr=infile,colors=colors,
@@ -1219,7 +1219,7 @@ class Parser:
     def __init__(self, raw, colors=None, title='', out=sys.stdout,
                    markup='html', header=None, footer=None, linenumbers=0):
         """Store the source text & set some flags"""
-        if colors == None:
+        if colors is None:
             colors = defaultColors
         self.raw = raw.expandtabs().rstrip()
         self.title = os.path.basename(title)
@@ -1611,7 +1611,7 @@ class Parser:
         getattr(self, '_do%sStart'%(self.markup))()
 
     def _doPageHeader(self):
-        if self.header != None:
+        if self.header is not None:
             if self.header.find('#$#') != -1 or \
                 self.header.find('#$#') != -1 or \
                 self.header.find('#%#') != -1:
@@ -1622,7 +1622,7 @@ class Parser:
                 getattr(self, '_do%sHeader'%(self.markup))()
 
     def _doPageFooter(self):
-        if self.footer != None:
+        if self.footer is not None:
             if self.footer.find('#$#') != -1 or \
                 self.footer.find('#@#') != -1 or \
                 self.footer.find('#%#') != -1:
@@ -1859,7 +1859,7 @@ content="text/html;charset=iso-8859-1">\n')
             if seperate_sides==0 and border:
                     style.append('border: %s %s;'%(border,size))
             else:
-                if border == None:
+                if border is None:
                    border = 'solid'
                 if 'v' in tags:# bottom border
                     style.append('border-bottom:%s %s;'%(border,size))

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -732,7 +732,7 @@ def cli():
         if o in ["-c", "--color"]:
             try:
                 colorscheme = globals().get(a.lower())
-            except:
+            except Exception:
                 traceback.print_exc()
                 Usage()
     if test:
@@ -765,7 +765,7 @@ def cli():
                         str2file(sys.stdin.read(), outfile=output, show=show,
                                 markup=markup, header=header, footer=footer,
                                 linenumbers=linenumbers, form=form)
-            except:
+            except Exception:
                 traceback.print_exc()
                 Usage()
     else:
@@ -1119,7 +1119,7 @@ def pageconvert(path, out=None, colors=lite, markup='xhtml', linenumbers=0,
         if not os.path.exists(newpath):
             try:
                 os.makedirs(os.path.dirname(newpath))
-            except:
+            except Exception:
                 pass#traceback.print_exc()
                 #Usage()
         y = open(newpath, 'w')
@@ -1134,7 +1134,7 @@ def pageconvert(path, out=None, colors=lite, markup='xhtml', linenumbers=0,
         if show:
             try:
                 os.startfile(newpath)
-            except:
+            except Exception:
                 traceback.print_exc()
         return newpath
     else:
@@ -1166,7 +1166,7 @@ def showpage(path):
     try:
         import webbrowser
         webbrowser.open_new(os.path.abspath(path))
-    except:
+    except Exception:
         traceback.print_exc()
 
 def _printinfo(message, quiet):
@@ -1602,7 +1602,7 @@ class Parser:
             _file = open(filepath,'r')
             content = _file.read()
             _file.close()
-        except:
+        except Exception:
             traceback.print_exc()
             content = ''
         return content

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -1212,7 +1212,7 @@ class InputError(PySourceColorError):
 
 ########################################################## Python code parser
 
-class Parser(object):
+class Parser:
 
     """MoinMoin python parser heavily chopped :)"""
 

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -1298,13 +1298,13 @@ class Parser:
         ## function for each token till done.
         # Parse the source and write out the results.
         try:
-            tokenize.tokenize(text.readline, self)
-        except tokenize.TokenError as ex:
-            msg = ex[0]
-            line = ex[1][0]
+            for token in tokenize.generate_tokens(text.readline):
+                self(*token)
+        except tokenize.TokenError as error:
+            msg = error.args[0]
+            line = error.args[1][0]
             self.out.write("<h3>ERROR: %s</h3>%s\n"%
                             (msg, self.raw[self.lines[line]:]))
-            #traceback.print_exc()
 
         # Markup end
         if self.addEnds:

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -1143,23 +1143,11 @@ def pageconvert(path, out=None, colors=lite, markup='xhtml', linenumbers=0,
 ##################################################################### helpers
 
 def walkdir(dir):
-    """Return a list of .py and .pyw files from a given directory.
-
-       This function can be written as a generator Python 2.3, or a genexp
-       in Python 2.4. But 2.2 and 2.1 would be left out....
-    """
+    """Return a list of .py and .pyw files from a given directory."""
     # Get a list of files that match *.py*
-    GLOB_PATTERN = os.path.join(dir, "*.[p][y]*")
-    pathlist = glob.glob(GLOB_PATTERN)
+    pathlist = glob.glob(os.path.join(dir, "*.[p][y]*"))
     # Now filter out all but py and pyw
-    filterlist = [x for x in pathlist
-                        if x.endswith('.py')
-                        or x.endswith('.pyw')]
-    if filterlist != []:
-        # if we have a list send it
-        return filterlist
-    else:
-        return None
+    return [x for x in pathlist if x.endswith(('.py', '.pyw'))] or None
 
 def showpage(path):
     """Helper function to open webpages"""

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -1,4 +1,3 @@
-# -*- coding: Latin-1 -*-
 """
 PySourceColor: color Python source code
 """
@@ -182,7 +181,7 @@ __version__ = "2.1a"
 __date__ = '25 April 2005'
 __author__ = "M.E.Farmer Jr."
 __credits__ = '''This was originally based on a python recipe
-submitted by Jürgen Hermann to ASPN. Now based on the voices in my head.
+submitted by JÃ¼rgen Hermann to ASPN. Now based on the voices in my head.
 M.E.Farmer 2004, 2005
 Python license
 '''
@@ -842,7 +841,7 @@ def LlamasRLumpy():
    """
    u"""
 =============================
-A Møøse once bit my sister...
+A MÃ¸Ã¸se once bit my sister...
 =============================
    """
    ## Relax, this won't hurt a bit, just a simple, painless procedure,
@@ -850,12 +849,12 @@ A Møøse once bit my sister...
    m = {'three':'1','won':'2','too':'3'}
    o = r'fishy\fishy\fishy/fish\oh/where/is\my/little\..'
    python = uR"""
- No realli! She was Karving her initials øn the møøse with the sharpened end
- of an interspace tøøthbrush given her by Svenge - her brother-in-law -an Oslo
- dentist and star of many Norwegian møvies: "The Høt Hands of an Oslo
- Dentist", "Fillings of Passion", "The Huge Mølars of Horst Nordfink"..."""
+ No realli! She was Karving her initials Ã¸n the mÃ¸Ã¸se with the sharpened end
+ of an interspace tÃ¸Ã¸thbrush given her by Svenge - her brother-in-law -an Oslo
+ dentist and star of many Norwegian mÃ¸vies: "The HÃ¸t Hands of an Oslo
+ Dentist", "Fillings of Passion", "The Huge MÃ¸lars of Horst Nordfink"..."""
    RU"""142 MEXICAN WHOOPING LLAMAS"""#<-Can you fit 142 llamas in a red box?
-   n = u' HERMSGERVØRDENBRØTBØRDA ' + """ YUTTE """
+   n = u' HERMSGERVÃ˜RDENBRÃ˜TBÃ˜RDA ' + """ YUTTE """
    t = """SAMALLNIATNUOMNAIRODAUCE"""+"DENIARTYLLAICEPS04"
    ## We apologise for the fault in the
    ## comments. Those responsible have been

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -186,6 +186,8 @@ submitted by Jürgen Hermann to ASPN. Now based on the voices in my head.
 M.E.Farmer 2004, 2005
 Python license
 '''
+
+import io
 import os
 import sys
 import time
@@ -195,7 +197,7 @@ import keyword
 import token
 import tokenize
 import traceback
-from io import StringIO
+
 # Do not edit
 NAME = token.NAME
 NUMBER = token.NUMBER
@@ -912,7 +914,7 @@ def str2html(sourcestring, colors=None, title='',
        form='code',or'snip' (for "<pre>yourcode</pre>" only)
        colors=null,mono,lite,dark,dark2,idle,or pythonwin
     """
-    stringIO = StringIO.StringIO()
+    stringIO = io.StringIO()
     Parser(sourcestring, colors=colors, title=title, out=stringIO,
            markup=markup, header=header, footer=footer,
            linenumbers=linenumbers).format(form)
@@ -929,7 +931,7 @@ def str2css(sourcestring, colors=None, title='',
     """
     if markup.lower() not in ['css' ,'xhtml']:
         markup = 'css'
-    stringIO = StringIO.StringIO()
+    stringIO = io.StringIO()
     parse = Parser(sourcestring, colors=colors, title=title,
                    out=stringIO, markup=markup,
                    header=header, footer=footer,
@@ -986,7 +988,7 @@ def path2html(sourcepath, colors=None, markup='html',
        form='code',or'snip' (for "<pre>yourcode</pre>" only)
        colors=null,mono,lite,dark,dark2,idle,or pythonwin
     """
-    stringIO = StringIO.StringIO()
+    stringIO = io.StringIO()
     sourcestring = open(sourcepath).read()
     Parser(sourcestring, colors, title=sourcepath, out=stringIO,
            markup=markup, header=header, footer=footer,
@@ -1286,7 +1288,7 @@ class Parser:
 
         # Wrap text in a filelike object
         self.pos = 0
-        text = StringIO.StringIO(self.raw)
+        text = io.StringIO(self.raw)
 
         # Markup start
         if self.addEnds:

--- a/paste/util/PySourceColor.py
+++ b/paste/util/PySourceColor.py
@@ -614,7 +614,7 @@ def Usage():
              saves it as pystyle.css in the same directory.
              html markup will silently ignore this flag.
      -H, --header
-         Opional-> add a page header to the top of the output
+         Optional-> add a page header to the top of the output
          -H
              Builtin header (name,date,hrule)
          --header
@@ -623,7 +623,7 @@ def Usage():
              and must handle its own font colors.
              ex. --header c:/tmp/header.txt
      -F, --footer
-         Opional-> add a page footer to the bottom of the output
+         Optional-> add a page footer to the bottom of the output
          -F
              Builtin footer (hrule,name,date)
          --footer
@@ -666,7 +666,7 @@ def Usage():
       python PySourceColor.py -i- -o c:/pydoc.py.html -s < c:/Python22/my.py
  _____________________________________________________________________________
  """
-    print(doc % (__version__))
+    print(doc % (__version__,))
     sys.exit(1)
 
 ###################################################### Command line interface
@@ -783,7 +783,6 @@ def cli():
                         footer=footer, linenumbers=linenumbers, form=form)
         else:
             raise PathError('File does not exists!')
-            Usage()
 
 ######################################################### Simple markup tests
 
@@ -893,7 +892,7 @@ def str2stdout(sourcestring, colors=None, title='', markup='html',
            header=header, footer=footer,
            linenumbers=linenumbers).format(form)
 
-def path2stdout(sourcepath, title='', colors=None, markup='html',
+def path2stdout(sourcepath, colors=None, markup='html',
                    header=None, footer=None,
                    linenumbers=0, form=None):
     """Converts code(file) to colorized HTML. Writes to stdout.
@@ -963,7 +962,7 @@ def str2file(sourcestring, outfile, colors=None, title='',
 
        makes no attempt at correcting bad pathnames
     """
-    css , html = str2markup(sourcestring, colors=colors, title='',
+    css , html = str2markup(sourcestring, colors=colors, title=title,
                     markup=markup, header=header, footer=footer,
                     linenumbers=linenumbers, form=form)
     # write html
@@ -1097,7 +1096,8 @@ def tagreplace(sourcestr, colors=lite, markup='xhtml',
                end = sourcestr[dataend+len(tagend):]
                sourcestr =  ''.join([start,data,end])
         else:
-            raise InputError('Tag mismatch!\nCheck %s,%s tags'%tagstart,tagend)
+            raise InputError(
+                'Tag mismatch!\nCheck %s,%s tags'%(tagstart,tagend))
     if not dosheet:
         css = None
     return css, sourcestr
@@ -1267,9 +1267,7 @@ class Parser:
         lines = self.raw.splitlines(0)
         for l in lines:
              # span and div escape for customizing and embedding raw text
-             if (l.startswith('#$#')
-                  or l.startswith('#%#')
-                  or l.startswith('#@#')):
+             if l.startswith(('#$#', '#%#', '#@#')):
                 newlines.append(l)
              else:
                 # kludge for line spans in css,xhtml
@@ -1282,7 +1280,8 @@ class Parser:
         # Gather lines
         while 1:
             pos = self.raw.find('\n', pos) + 1
-            if not pos: break
+            if not pos:
+                break
             self.lines.append(pos)
         self.lines.append(len(self.raw))
 
@@ -1341,7 +1340,7 @@ class Parser:
         if newpos > oldpos:
             if self.raw[oldpos:newpos].isspace():
                 # consume a single space after linestarts and linenumbers
-                # had to have them so tokenizer could seperate them.
+                # had to have them so tokenizer could separate them.
                 # multiline strings are handled by do_Text functions
                 if self.lasttext != self.LINESTART \
                         and self.lasttext != self.LINENUMHOLDER:
@@ -1351,7 +1350,7 @@ class Parser:
             else:
                 slash = self.raw[oldpos:newpos].find('\\')+oldpos
                 self.out.write(self.raw[oldpos:slash])
-                getattr(self, '_send%sText'%(self.markup))(OPERATOR, '\\')
+                getattr(self, '_send%sText'%(self.markup,))(OPERATOR, '\\')
                 self.linenum+=1
                 # kludge for line spans in css,xhtml
                 if self.markup in ['XHTML','CSS']:
@@ -1364,7 +1363,7 @@ class Parser:
             return
 
         # Look for operators
-        if token.LPAR <= toktype and toktype <= token.OP:
+        if token.LPAR <= toktype <= token.OP:
             # Trap decorators py2.4 >
             if toktext == '@':
                 toktype = DECORATOR
@@ -1379,7 +1378,7 @@ class Parser:
                     # Find the end for arguments
                     elif toktext == ':':
                         self.argFlag = 0
-                ## Seperate the diffrent operator types
+                ## Separate the different operator types
                 # Brackets
                 if self.doBrackets and toktext in ['[',']','(',')','{','}']:
                     toktype = BRACKETS
@@ -1432,33 +1431,33 @@ class Parser:
         elif toktype == token.STRING:
             text = toktext.lower()
             # TRIPLE DOUBLE QUOTE's
-            if (text[:3] == '"""'):
+            if text[:3] == '"""':
                 toktype = TRIPLEDOUBLEQUOTE
-            elif (text[:4] == 'r"""'):
+            elif text[:4] == 'r"""':
                 toktype = TRIPLEDOUBLEQUOTE_R
-            elif (text[:4] == 'u"""' or
-                   text[:5] == 'ur"""'):
+            elif ('u"""' == text[:4] or
+                  text[:5] == 'ur"""'):
                 toktype = TRIPLEDOUBLEQUOTE_U
             # DOUBLE QUOTE's
-            elif (text[:1] == '"'):
+            elif text[:1] == '"':
                 toktype = DOUBLEQUOTE
-            elif (text[:2] == 'r"'):
+            elif text[:2] == 'r"':
                 toktype = DOUBLEQUOTE_R
             elif (text[:2] == 'u"' or
-                   text[:3] == 'ur"'):
+                  text[:3] == 'ur"'):
                 toktype = DOUBLEQUOTE_U
             # TRIPLE SINGLE QUOTE's
-            elif (text[:3] == "'''"):
+            elif text[:3] == "'''":
                  toktype = TRIPLESINGLEQUOTE
-            elif (text[:4] == "r'''"):
+            elif text[:4] == "r'''":
                 toktype = TRIPLESINGLEQUOTE_R
             elif (text[:4] == "u'''" or
-                   text[:5] == "ur'''"):
+                  text[:5] == "ur'''"):
                 toktype = TRIPLESINGLEQUOTE_U
             # SINGLE QUOTE's
-            elif (text[:1] == "'"):
+            elif text[:1] == "'":
                 toktype = SINGLEQUOTE
-            elif (text[:2] == "r'"):
+            elif text[:2] == "r'":
                 toktype = SINGLEQUOTE_R
             elif (text[:2] == "u'" or
                    text[:3] == "ur'"):
@@ -1568,7 +1567,7 @@ class Parser:
             toktext = escape(toktext)
 
         # Send text for any markup
-        getattr(self, '_send%sText'%(self.markup))(toktype, toktext)
+        getattr(self, '_send%sText'%(self.markup,))(toktype, toktext)
         return
 
     ################################################################# Helpers
@@ -1602,14 +1601,13 @@ class Parser:
 
     def _doPageHeader(self):
         if self.header is not None:
-            if self.header.find('#$#') != -1 or \
-                self.header.find('#$#') != -1 or \
-                self.header.find('#%#') != -1:
+            if ('#$#' in self.header or '#@#' in self.header
+                    or '#%' in self.header):
                 self.out.write(self.header[3:])
             else:
                 if self.header != '':
                     self.header = self._getFile(self.header)
-                getattr(self, '_do%sHeader'%(self.markup))()
+                getattr(self, '_do%sHeader'%(self.markup,))()
 
     def _doPageFooter(self):
         if self.footer is not None:
@@ -1620,7 +1618,7 @@ class Parser:
             else:
                 if self.footer != '':
                     self.footer = self._getFile(self.footer)
-                getattr(self, '_do%sFooter'%(self.markup))()
+                getattr(self, '_do%sFooter'%(self.markup,))()
 
     def _doPageEnd(self):
         getattr(self, '_do%sEnd'%(self.markup))()
@@ -1670,7 +1668,7 @@ class Parser:
         # Start of html page
         self.out.write('<!DOCTYPE html PUBLIC \
 "-//W3C//DTD HTML 4.01//EN">\n')
-        self.out.write('<html><head><title>%s</title>\n'%(self.title))
+        self.out.write('<html><head><title>%s</title>\n'%(self.title,))
         self.out.write(self._getDocumentCreatedBy())
         self.out.write('<meta http-equiv="Content-Type" \
 content="text/html;charset=iso-8859-1">\n')
@@ -1727,8 +1725,7 @@ content="text/html;charset=iso-8859-1">\n')
                 splittext = toktext.split(self.LINENUMHOLDER)
             else:
                 splittext = toktext.split(self.LINENUMHOLDER+' ')
-            store = []
-            store.append(splittext.pop(0))
+            store = [splittext.pop(0)]
             lstarttag, lendtag, lcolor = self._getHTMLStyles(LINENUMBER, toktext)
             count = len(splittext)
             for item in splittext:
@@ -1869,7 +1866,7 @@ content="text/html;charset=iso-8859-1">\n')
         # text backcolor
         if backcolor:
             style.append('background-color:%s;'%backcolor)
-        return (self._getMarkupClass(key),' '.join(style))
+        return self._getMarkupClass(key), ' '.join(style)
 
     def _sendCSSStyle(self, external=0):
         """ create external and internal style sheets"""
@@ -1899,7 +1896,7 @@ content="text/html;charset=iso-8859-1">\n')
     def _doCSSStart(self):
         # Start of css/html 4.01 page
         self.out.write('<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">\n')
-        self.out.write('<html><head><title>%s</title>\n'%(self.title))
+        self.out.write('<html><head><title>%s</title>\n'%(self.title,))
         self.out.write(self._getDocumentCreatedBy())
         self.out.write('<meta http-equiv="Content-Type" \
 content="text/html;charset=iso-8859-1">\n')
@@ -1938,7 +1935,7 @@ href="pystyle.css" type="text/css">')
             # <linestart> <lnumstart> lnum <lnumend> text <lineend>
             #################################################
             newmarkup = MARKUPDICT.get(LINENUMBER, MARKUPDICT[NAME])
-            lstartspan = '<span class="%s">'%(newmarkup)
+            lstartspan = '<span class="%s">'%(newmarkup,)
             if toktype == LINENUMBER:
                 splittext = toktext.split(self.LINENUMHOLDER)
             else:
@@ -1976,7 +1973,7 @@ href="pystyle.css" type="text/css">')
                 #handle line numbers if present
                 if self.dolinenums:
                     item = item.replace('</span>',
-                           '</span><span class="%s">'%(markupclass))
+                           '</span><span class="%s">'%(markupclass,))
                 else:
                     item = '<span class="%s">%s'%(markupclass,item)
                 # add endings for line and string tokens
@@ -1989,12 +1986,12 @@ href="pystyle.css" type="text/css">')
         # Send text
         if toktype != LINENUMBER:
             if toktype == TEXT and self.textFlag == 'DIV':
-                startspan = '<div class="%s">'%(markupclass)
+                startspan = '<div class="%s">'%(markupclass,)
                 endspan = '</div>'
             elif toktype == TEXT and self.textFlag == 'RAW':
                 startspan,endspan = ('','')
             else:
-                startspan = '<span class="%s">'%(markupclass)
+                startspan = '<span class="%s">'%(markupclass,)
                 endspan = '</span>'
             self.out.write(''.join([startspan, toktext, endspan]))
         else:
@@ -2036,7 +2033,7 @@ href="pystyle.css" type="text/css">')
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"\n \
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n \
 <html xmlns="http://www.w3.org/1999/xhtml">\n')
-        self.out.write('<head><title>%s</title>\n'%(self.title))
+        self.out.write('<head><title>%s</title>\n'%(self.title,))
         self.out.write(self._getDocumentCreatedBy())
         self.out.write('<meta http-equiv="Content-Type" \
 content="text/html;charset=iso-8859-1"/>\n')

--- a/paste/util/__init__.py
+++ b/paste/util/__init__.py
@@ -2,3 +2,13 @@
 Package for miscellaneous routines that do not depend on other parts
 of Paste
 """
+
+
+class NoDefault:
+    """Sentinel for parameters without default value."""
+
+    def __repr__(self):
+        return '<NoDefault>'
+
+
+NO_DEFAULT = NoDefault()

--- a/paste/util/cgitb_hook.py
+++ b/paste/util/cgitb_hook.py
@@ -29,7 +29,7 @@ Content-Type: text/html
 </table> </table> </table> </table> </table> </font> </font> </font>'''
 
 
-__UNDEF__ = []  # a special sentinel object
+__UNDEF__ = object()  # a special sentinel object
 
 
 def small(text):

--- a/paste/util/cgitb_hook.py
+++ b/paste/util/cgitb_hook.py
@@ -1,4 +1,4 @@
-"""Hook class from the deprecated cgitb library."""
+"""Hook class from the deprecated cgitb module of the standard library."""
 
 # Copyright © 2001-2023 Python Software Foundation; All Rights Reserved.
 

--- a/paste/util/classinstance.py
+++ b/paste/util/classinstance.py
@@ -1,7 +1,7 @@
 # (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
 # Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 
-class classinstancemethod(object):
+class classinstancemethod:
     """
     Acts like a class method when called from a class, like an
     instance method when called by an instance.  The method should
@@ -16,7 +16,7 @@ class classinstancemethod(object):
     def __get__(self, obj, type=None):
         return _methodwrapper(self.func, obj=obj, type=type)
 
-class _methodwrapper(object):
+class _methodwrapper:
 
     def __init__(self, func, obj, type):
         self.func = func

--- a/paste/util/datetimeutil.py
+++ b/paste/util/datetimeutil.py
@@ -63,7 +63,7 @@ __all__ = ['parse_timedelta', 'normalize_timedelta',
 def _number(val):
     try:
         return int(val)
-    except:
+    except Exception:
         return None
 
 #

--- a/paste/util/filemixin.py
+++ b/paste/util/filemixin.py
@@ -1,7 +1,7 @@
 # (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
 # Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 
-class FileMixin(object):
+class FileMixin:
 
     """
     Used to provide auxiliary methods to objects simulating files.

--- a/paste/util/intset.py
+++ b/paste/util/intset.py
@@ -76,7 +76,7 @@ _MAXINF = _Infinity(False)
 # Integer set class
 # -----------------
 
-class IntSet(object):
+class IntSet:
     """Integer set class with efficient storage in a RLE format of ranges.
     Supports minus and plus infinity in the range."""
 

--- a/paste/util/intset.py
+++ b/paste/util/intset.py
@@ -1,4 +1,3 @@
-# -*- coding: iso-8859-15 -*-
 """Immutable integer set type.
 
 Integer set class.

--- a/paste/util/ip4.py
+++ b/paste/util/ip4.py
@@ -1,4 +1,3 @@
-# -*- coding: iso-8859-15 -*-
 """IP4 address range set implementation.
 
 Implements an IPv4-range type.

--- a/paste/util/looper.py
+++ b/paste/util/looper.py
@@ -59,7 +59,7 @@ class looper_iter:
         return result
     __next__ = next
 
-class loop_pos(object):
+class loop_pos:
 
     def __init__(self, seq, pos):
         self.seq = seq

--- a/paste/util/template.py
+++ b/paste/util/template.py
@@ -76,7 +76,7 @@ class _TemplateContinue(Exception):
 class _TemplateBreak(Exception):
     pass
 
-class Template(object):
+class Template:
 
     default_namespace = {
         'start_braces': '{{',
@@ -309,7 +309,7 @@ class bunch(dict):
 ## HTML Templating
 ############################################################
 
-class html(object):
+class html:
     def __init__(self, value):
         self.value = value
     def __str__(self):

--- a/paste/util/template.py
+++ b/paste/util/template.py
@@ -210,7 +210,7 @@ class Template:
         try:
             value = eval(code, ns)
             return value
-        except:
+        except Exception:
             exc_info = sys.exc_info()
             e = exc_info[1]
             if getattr(e, 'args'):
@@ -224,7 +224,7 @@ class Template:
         __traceback_hide__ = True
         try:
             exec(code, ns)
-        except:
+        except Exception:
             exc_info = sys.exc_info()
             e = exc_info[1]
             e.args = (self._add_line_info(e.args[0], pos),)
@@ -236,7 +236,7 @@ class Template:
             if value is None:
                 return ''
             value = str(value)
-        except:
+        except Exception:
             exc_info = sys.exc_info()
             e = exc_info[1]
             e.args = (self._add_line_info(e.args[0], pos),)

--- a/paste/util/threadinglocal.py
+++ b/paste/util/threadinglocal.py
@@ -9,7 +9,7 @@ try:
     import threading
 except ImportError:
     # No threads, so "thread local" means process-global
-    class local(object):
+    class local:
         pass
 else:
     try:
@@ -17,7 +17,7 @@ else:
     except AttributeError:
         # Added in 2.4, but now we'll have to define it ourselves
         import thread
-        class local(object):
+        class local:
 
             def __init__(self):
                 self.__dict__['__objs'] = {}

--- a/paste/wsgilib.py
+++ b/paste/wsgilib.py
@@ -134,7 +134,7 @@ class chained_app_iters:
             try:
                 if hasattr(app_iter, 'close'):
                     app_iter.close()
-            except:
+            except Exception:
                 got_exc = sys.exc_info()
         if got_exc:
             raise got_exc
@@ -182,7 +182,7 @@ def catch_errors(application, environ, start_response, error_callback,
     """
     try:
         app_iter = application(environ, start_response)
-    except:
+    except Exception:
         error_callback(sys.exc_info())
         raise
     if type(app_iter) in (list, tuple):
@@ -213,7 +213,7 @@ class _wrap_app_iter:
             if self.ok_callback:
                 self.ok_callback()
             raise
-        except:
+        except Exception:
             self.error_callback(sys.exc_info())
             raise
     __next__ = next
@@ -269,7 +269,7 @@ class _wrap_app_iter_app:
             if hasattr(self.app_iterable, 'close'):
                 try:
                     self.app_iterable.close()
-                except:
+                except Exception:
                     # @@: Print to wsgi.errors?
                     pass
             new_app_iterable = self.error_callback_app(
@@ -586,7 +586,7 @@ def _warn_deprecated(new_func):
         return new_func(*args, **kw)
     try:
         replacement.func_name = new_func.func_name
-    except:
+    except Exception:
         pass
     return replacement
 

--- a/paste/wsgilib.py
+++ b/paste/wsgilib.py
@@ -62,7 +62,7 @@ class add_close:
                 "WSGI request. finalization function %s not called"
                   % self.close_func, file=sys.stderr)
 
-class add_start_close(object):
+class add_start_close:
     """
     An an iterable that iterates over app_iter, calls start_func
     before the first item is returned, then calls close_func at the
@@ -101,7 +101,7 @@ class add_start_close(object):
                 "WSGI request. finalization function %s not called"
                   % self.close_func, file=sys.stderr)
 
-class chained_app_iters(object):
+class chained_app_iters:
 
     """
     Chains several app_iters together, also delegating .close() to each
@@ -146,7 +146,7 @@ class chained_app_iters(object):
                 "WSGI request. finalization function %s not called"
                   % self.close_func, file=sys.stderr)
 
-class encode_unicode_app_iter(object):
+class encode_unicode_app_iter:
     """
     Encodes an app_iterable's unicode responses as strings
     """
@@ -193,7 +193,7 @@ def catch_errors(application, environ, start_response, error_callback,
     else:
         return _wrap_app_iter(app_iter, error_callback, ok_callback)
 
-class _wrap_app_iter(object):
+class _wrap_app_iter:
 
     def __init__(self, app_iterable, error_callback, ok_callback):
         self.app_iterable = app_iterable
@@ -241,7 +241,7 @@ def catch_errors_app(application, environ, start_response, error_callback_app,
             environ, start_response, app_iter,
             error_callback_app, ok_callback, catch=catch)
 
-class _wrap_app_iter_app(object):
+class _wrap_app_iter_app:
 
     def __init__(self, environ, start_response, app_iterable,
                  error_callback_app, ok_callback, catch=Exception):
@@ -370,7 +370,7 @@ def raw_interactive(application, path='', raise_on_wsgi_error=False,
     return (data['status'], data['headers'], b''.join(output),
             errors.getvalue())
 
-class ErrorRaiser(object):
+class ErrorRaiser:
 
     def flush(self):
         pass

--- a/paste/wsgiwrappers.py
+++ b/paste/wsgiwrappers.py
@@ -34,7 +34,7 @@ class DeprecatedSettings(StackedObjectProxy):
 # settings is deprecated: use WSGIResponse.defaults instead
 settings = DeprecatedSettings(default=dict())
 
-class environ_getter(object):
+class environ_getter:
     """For delegating an attribute to a key in self.environ."""
     # @@: Also __set__?  Should setting be allowed?
     def __init__(self, key, default='', default_factory=None):
@@ -55,7 +55,7 @@ class environ_getter(object):
     def __repr__(self):
         return '<Proxy for WSGI environ %r key>' % self.key
 
-class WSGIRequest(object):
+class WSGIRequest:
     """WSGI Request API Object
 
     This object represents a WSGI request with a more friendly interface.
@@ -287,7 +287,7 @@ class WSGIRequest(object):
         msg += '\ncookies=%s>' % pf(self.cookies)
         return msg
 
-class WSGIResponse(object):
+class WSGIResponse:
     """A basic HTTP response with content, headers, and out-bound cookies
 
     The class variable ``defaults`` specifies default values for

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,7 @@ def app_with_config(environ, start_response):
     lines = [line.encode('utf8') for line in lines]
     return lines
 
-class NestingAppWithConfig(object):
+class NestingAppWithConfig:
     def __init__(self, app):
         self.app = app
 

--- a/tests/test_exceptions/test_formatter.py
+++ b/tests/test_exceptions/test_formatter.py
@@ -63,14 +63,14 @@ def test_excersize():
     for f in formats:
         try:
             raise_error()
-        except:
+        except Exception:
             format(f)
 
 def test_content():
     for f in formats:
         try:
             raise_error()
-        except:
+        except Exception:
             result = format(f)
             print(result)
             assert 'test_object' in result
@@ -88,7 +88,7 @@ def test_trim():
     for f in formats:
         try:
             raise_error()
-        except:
+        except Exception:
             result = format(f, trim_source_paths=[(current, '.')])
             assert current not in result
             assert ('%stest_formatter.py' % os.sep) in result, ValueError(repr(result))
@@ -99,7 +99,7 @@ def test_hide():
     for f in formats:
         try:
             hide(True, raise_error)
-        except:
+        except Exception:
             result = format(f)
             print(result)
             assert 'in hide_inner' not in result
@@ -128,7 +128,7 @@ def test_hide_supppressed():
                     pass_through,
                     'b',
                     raise_error)
-            except:
+            except Exception:
                 results.append(format(f))
             else:
                 assert 0
@@ -149,7 +149,7 @@ def test_hide_after():
 
                 hide, 'reset',
                 raise_error)
-        except:
+        except Exception:
             result = format(f)
             assert 'AABB' in result
             assert 'CCDD' not in result
@@ -164,7 +164,7 @@ def test_hide_before():
                 'AABB',
                 hide, 'before',
                 raise_error)
-        except:
+        except Exception:
             result = format(f)
             print(result)
             assert 'AABB' not in result

--- a/tests/test_exceptions/test_formatter.py
+++ b/tests/test_exceptions/test_formatter.py
@@ -4,7 +4,7 @@ import sys
 import os
 import difflib
 
-class Mock(object):
+class Mock:
     def __init__(self, **kw):
         for name, value in kw.items():
             setattr(self, name, value)

--- a/tests/test_exceptions/test_reporter.py
+++ b/tests/test_exceptions/test_reporter.py
@@ -24,7 +24,7 @@ def test_logger():
         show_hidden_frames=False)
     try:
         int('a')
-    except:
+    except Exception:
         exc_data = collector.collect_exception(*sys.exc_info())
     else:
         assert 0
@@ -38,7 +38,7 @@ def test_logger():
 
     try:
         1 / 0
-    except:
+    except Exception:
         exc_data = collector.collect_exception(*sys.exc_info())
     else:
         assert 0

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -14,7 +14,7 @@ def test_fixture():
     res = app.delete('/')
     assert (res.request.environ['REQUEST_METHOD'] ==
             'DELETE')
-    class FakeDict(object):
+    class FakeDict:
         def items(self):
             return [('a', '10'), ('a', '20')]
     res = app.post('/params', params=FakeDict())
@@ -47,7 +47,7 @@ def test_fixture_form_end():
     TestApp(response).get('/')
 
 def test_params_and_upload_files():
-    class PostApp(object):
+    class PostApp:
         def __call__(self, environ, start_response):
             start_response("204 No content", [])
             self.request = WSGIRequest(environ)

--- a/tests/test_httpserver.py
+++ b/tests/test_httpserver.py
@@ -5,11 +5,11 @@ import socket
 from paste.httpserver import LimitedLengthFile, WSGIHandler, serve
 
 
-class MockServer(object):
+class MockServer:
     server_address = ('127.0.0.1', 80)
 
 
-class MockSocket(object):
+class MockSocket:
     def makefile(self, mode, bufsize):
         return io.StringIO()
 

--- a/tests/test_recursive.py
+++ b/tests/test_recursive.py
@@ -15,7 +15,7 @@ def error_docs_app(environ, start_response):
     else:
         return simple_app(environ, start_response)
 
-class Middleware(object):
+class Middleware:
     def __init__(self, app, url='/error'):
         self.app = app
         self.url = url

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -39,7 +39,7 @@ def simpleapp_withregistry_default(environ, start_response):
     return [body]
 
 
-class RegistryUsingApp(object):
+class RegistryUsingApp:
     def __init__(self, var, value, raise_exc=False):
         self.var = var
         self.value = value
@@ -57,7 +57,7 @@ class RegistryUsingApp(object):
         body = body.encode('utf8')
         return [body]
 
-class RegistryUsingIteratorApp(object):
+class RegistryUsingIteratorApp:
     def __init__(self, var, value):
         self.var = var
         self.value = value
@@ -72,7 +72,7 @@ class RegistryUsingIteratorApp(object):
         body = body.encode('utf8')
         return iter([body])
 
-class RegistryMiddleMan(object):
+class RegistryMiddleMan:
     def __init__(self, app, var, value, depth):
         self.app = app
         self.var = var

--- a/tests/test_wsgiwrappers.py
+++ b/tests/test_wsgiwrappers.py
@@ -6,7 +6,7 @@ from paste.fixture import TestApp
 from paste.wsgiwrappers import WSGIRequest, WSGIResponse
 from paste.util.field_storage import FieldStorage
 
-class AssertApp(object):
+class AssertApp:
     def __init__(self, assertfunc):
         self.assertfunc = assertfunc
 


### PR DESCRIPTION
Some clean-up since paste only supports Python 3 nowadays:

- in Python 3, we don't need to inherit from object
- [avoid bare excepts](https://stackoverflow.com/questions/54948548/what-is-wrong-with-using-a-bare-except)
- unify the use of "no default" sentinels inside paste
- source code encodings don't need to be specified